### PR TITLE
Fix null dereference on save

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -23,7 +23,7 @@ export class RevealServer {
     private editor: TextEditor;
 
     state = RevealServerState.Stopped;
-    uri: Uri;
+    public uri?: Uri;
 
     get title(): string {
         return `RevealJS : ${this.editor.document.fileName}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,7 +101,10 @@ export function activate(context: vscode.ExtensionContext) {
             if (document === vscode.window.activeTextEditor.document) {
                 let context = getContext();
                 statusBarController.update(context);
-                provider.update(context.server.uri);
+                
+                if (context.server.uri) {
+                    provider.update(context.server.uri);
+                }
             }
         }));
 


### PR DESCRIPTION
**Bug**
The `context.server.uri` is only set once the server has been started. Don't call refresh when it has not been set yet

Fixes #16