### PR TITLE
Fixed Google Chrome not opening in Linux

### DIFF
--- a/src/ChromeHelper.ts
+++ b/src/ChromeHelper.ts
@@ -61,8 +61,7 @@ chromeAppNames[Platform.Windows] = 'chrome'
 
 export const openInChrome = async (url: string, headless?: boolean) => {
   try {
-    const platform = getPlatform()
-    const chromeApp = chromeAppNames[platform]
+    const chromeApp = getBrowserPath();
     if (headless) {
       return await opn(url, { app: [chromeApp, '--headless'] })
     }


### PR DESCRIPTION
When trying to export a presentation to the browser an error would always occur because the extension could not find the Chrome binary. By changing the code to get the path using an existing function, the problem seems to be solved.