### PR TITLE
WIP : initial attempt at supporting custom plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ This extension let you display a reveal.js presentation directly from an opened 
 Create reveal.js presentation directly from markdown file,
 open or create a new file in markdown and use default slide separator to see slide counter change in the status bar and title appear in the sidebar.
 
-Since Reveal.js use marked to parse the markdown string you can use this in your document: 
+Since Reveal.js use marked to parse the markdown string you can use this in your document:
 
 - GitHub flavored markdown.
 - GFM tables
 
-If you need a sample file you can get it here:  
+If you need a sample file you can get it here:
 https://raw.githubusercontent.com/evilz/vscode-reveal/master/sample.md
 
 
@@ -52,24 +52,24 @@ The list will show the first line of text that is found in the slide, most of th
 Blue icon is used to show horizontal slide, orange is used for vertical ones.
 
 Clicking on slide name will move the cursor on beginning of the slide in the editor.
-If the preview is opened it will also show the selected slide on it.  
+If the preview is opened it will also show the selected slide on it.
 
 ![](https://github.com/evilz/vscode-reveal/raw/master/images/sidebar.png)
 
 
 ## <a id="theme"></a> Theme
 
-reveal.js comes with a few themes built in: 
-- Black (default) 
-- White 
-- League 
-- Sky 
-- Beige 
-- Simple 
-- Serif 
-- Blood 
-- Night 
-- Moon 
+reveal.js comes with a few themes built in:
+- Black (default)
+- White
+- League
+- Sky
+- Beige
+- Simple
+- Serif
+- Blood
+- Night
+- Moon
 - Solarized
 
 You can set it using `revealjs.theme` parameter in Vs code config or in the document itself using front matter.
@@ -77,7 +77,7 @@ You can set it using `revealjs.theme` parameter in Vs code config or in the docu
 If you want a custom theme you can do it!
 Just add custom style to a CSS file in the same folder that your markdown.
 
-example: 
+example:
 if your file name is `my-theme.css` just add this in the front matter header :
 
 ```
@@ -103,6 +103,32 @@ highlightTheme : "other theme"
 ```
 
 Get the theme list here https://highlightjs.org/
+
+## <a id="extra-plugins"></a> Adding Your Own Reveal.js Plugins
+
+The Reveal ecosystem contains a number of useful [plugins](https://github.com/hakimel/reveal.js/wiki/Plugins,-Tools-and-Hardware). Some on these (notes, highlight, and math) are included automatically with vscode-reveal. You can install others locally in your project.
+
+1. Use `npm install` to load the plugin you want into your project. This will create a `node_modules` subdirectory if these isn't one already.
+
+2. Add a `customPlugins` line to your document's header. This should be followed by a list of the plugins you want to include. For each, you specify its main file as a path, relative to the `node_modules` directory.
+
+3. If the plugin, requires initialization, create a `customJavascript` section in the header and write the initialization code there.
+
+For example, to include the `reveal-code-focus` plugin, your header might look like this:
+
+~~~
+---
+customPlugins:
+  - "reveal-code-focus/reveal-code-focus.js"
+
+customJavascript: |
+  window.RevealCodeFocus({});
+---
+~~~
+
+This feature is experimental: Reveal.js is a bit touchy when it comes to load order, and some plugins may not work.
+
+
 
 ## <a id="options"></a> Reveal.js Options
 
@@ -189,4 +215,3 @@ This will try to launch Chrome in headless or your default browser it takes abou
 ## Known Issues
 
 Please add issues on github.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-reveal",
-  "version": "1.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -103,14 +103,6 @@
       "requires": {
         "mime-types": "2.1.17",
         "negotiator": "0.6.1"
-      }
-    },
-    "agent-base": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
-      "requires": {
-        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -231,11 +223,6 @@
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -268,7 +255,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -325,6 +313,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -473,17 +462,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      }
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -514,7 +494,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cryptiles": {
       "version": "2.0.5",
@@ -702,19 +683,6 @@
         "once": "1.4.0"
       }
     },
-    "es6-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
-      "integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "4.2.2"
-      }
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -843,35 +811,6 @@
         }
       }
     },
-    "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
-      "requires": {
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.0",
-        "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "yauzl": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-          "requires": {
-            "fd-slicer": "1.0.1"
-          }
-        }
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -904,6 +843,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
       "requires": {
         "pend": "1.2.0"
       }
@@ -1008,7 +948,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fstream": {
       "version": "1.0.11",
@@ -1652,25 +1593,6 @@
         "sshpk": "1.13.1"
       }
     },
-    "https-proxy-agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
-      "requires": {
-        "agent-base": "4.1.2",
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -1680,6 +1602,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -1819,12 +1742,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -2316,6 +2235,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -2386,7 +2306,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -2417,7 +2338,8 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -2449,12 +2371,8 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.2",
@@ -2465,31 +2383,11 @@
         "ipaddr.js": "1.5.2"
       }
     },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
-    },
-    "puppeteer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.0.0.tgz",
-      "integrity": "sha512-e00NMdUL32YhBcua9OkVXHgyDEMBWJhDXkYNv0pyKRU1Z1OrsRm5zCpppAdxAsBI+/MJBspFNfOUZuZ24qPGMQ==",
-      "requires": {
-        "debug": "2.6.9",
-        "extract-zip": "1.6.6",
-        "https-proxy-agent": "2.1.1",
-        "mime": "1.4.1",
-        "progress": "2.0.0",
-        "proxy-from-env": "1.0.0",
-        "rimraf": "2.6.2",
-        "ws": "3.3.3"
-      }
     },
     "qs": {
       "version": "6.5.1",
@@ -2580,6 +2478,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -2794,6 +2693,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "7.1.2"
       },
@@ -2802,6 +2702,7 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -2815,6 +2716,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
           }
@@ -2981,6 +2883,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -3232,21 +3135,11 @@
         "mime-types": "2.1.17"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
     "typescript": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
       "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "unique-stream": {
       "version": "2.2.1",
@@ -3281,7 +3174,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -3548,28 +3442,11 @@
         }
       }
     },
-    "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "requires": {
-        "isexe": "2.0.0"
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-      "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
-      }
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   ],
   "main": "./out/src/extension",
   "contributes": {
-    "commands": [{
+    "commands": [
+      {
         "command": "vscode-revealjs.showRevealJS",
         "title": "Revealjs: Show presentation by side",
         "icon": {
@@ -254,14 +255,17 @@
       }
     },
     "views": {
-      "explorer": [{
-        "id": "slidesExplorer",
-        "name": "Slides",
-        "when": "slideExplorerEnabled"
-      }]
+      "explorer": [
+        {
+          "id": "slidesExplorer",
+          "name": "Slides",
+          "when": "slideExplorerEnabled"
+        }
+      ]
     },
     "menus": {
-      "view/title": [{
+      "view/title": [
+        {
           "command": "vscode-revealjs.showRevealJSInBrowser",
           "when": "view == slidesExplorer",
           "group": "navigation"
@@ -282,10 +286,12 @@
           "group": "navigation"
         }
       ],
-      "view/item/context": [{
-        "command": "vscode-revealjs.goToSlide",
-        "when": "view == slidesExplorer && viewItem == slideNode"
-      }]
+      "view/item/context": [
+        {
+          "command": "vscode-revealjs.goToSlide",
+          "when": "view == slidesExplorer && viewItem == slideNode"
+        }
+      ]
     }
   },
   "scripts": {

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -17,6 +17,8 @@ export interface IRevealJsOptions {
 
   customTheme?: string
   customHighlightTheme?: string
+  customPlugins?: string
+  customJavascript?: string
 
   controls: boolean
   progress: boolean
@@ -60,4 +62,3 @@ export interface ISlide {
   text: string
   verticalChildren?: ISlide[] // Rem : child can't have child
 }
-

--- a/src/Template.ts
+++ b/src/Template.ts
@@ -17,7 +17,7 @@ const renderTemplate = (title: string, revealOptions: IRevealJsOptions, slides: 
         <link rel="stylesheet" href="css/reveal.css">
         <link rel="stylesheet" href="css/theme/${revealOptions.theme}.css" id="theme">
         ${revealOptions.customTheme ? ` <link rel="stylesheet" href="${revealOptions.customTheme}.css" id="theme">` : ''}
-       
+
         <!-- For syntax highlighting -->
         <link rel="stylesheet" href="lib/css/${revealOptions.highlightTheme}.css">
 
@@ -29,9 +29,9 @@ const renderTemplate = (title: string, revealOptions: IRevealJsOptions, slides: 
         </script>
 
         <style type="text/css">
-            @page {    
+            @page {
               margin: 0;
-              size: auto; 
+              size: auto;
             }
         </style>
 
@@ -69,10 +69,20 @@ const renderTemplate = (title: string, revealOptions: IRevealJsOptions, slides: 
               { src: 'lib/js/classList.js', condition: function() { return !document.body.classList; } },
               { src: 'plugin/markdown/marked.js', condition: function() { return !!document.querySelector('[data-markdown]'); } },
               { src: 'plugin/markdown/markdown.js', condition: function() { return !!document.querySelector('[data-markdown]'); } },
-              { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
               { src: 'plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } },
               { src: 'plugin/math/math.js', async: true }
             ];
+
+            var extraPlugins = ${JSON.stringify(revealOptions.customPlugins || [])};
+            if (!extraPlugins.includes("reveal-code-focus/reveal-code-focus.js")) {
+              deps.push({ src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } });
+            }
+            else {
+              deps.push({ src: 'plugin/highlight/highlight.js', async: false });
+            }
+
+            deps = deps.concat(extraPlugins.map(name => { return { src: "node_modules/" + name, async: false }}));
+
             // default options to init reveal.js
             var defaultOptions = {
               controls: true,
@@ -88,8 +98,11 @@ const renderTemplate = (title: string, revealOptions: IRevealJsOptions, slides: 
             options = extend(defaultOptions, options, queryOptions);
             Reveal.initialize(options);
 
+            window.onload = () => {
+              ${revealOptions.customJavascript};
+            }
         </script>
-        
+
     </body>
 </html>`
 }


### PR DESCRIPTION
As you know, the reveal dependency mechanism is a bit of a mess: it assumes a static configuration. I've tried to enable plugins by adding two sections to the header:

customPlugins:  an array of plugin file names, and

customJavascript: a string where you can write Javascript that does any initialization required.

This works locally with reveal-code-focus, which is one of the uglier plugins, because it usurps highlightjs. 

I'd love to see something like this merged in, so I can use vscode for my class presentations.

Cheers


Dave Thomas