### PR TITLE
Improve html export

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/vsts/pipelines/languages/javascript
 
 pool:
-  vmImage: 'Ubuntu 16.04'
+  vmImage: 'vs2017-win2016'
 
 steps:
 - task: NodeTool@0
@@ -13,7 +13,12 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
-    npm install
-    npm run vscode:prepublish
-    npm test --silent
-  displayName: 'npm vscode:prepublish then test'
+    npm install && npm run vscode:prepublish && npm run unittest
+  displayName: 'npm unittest'
+
+- task: PublishTestResults@2
+  displayName: Publish Test Results
+  inputs:
+    testRunner: JUnit
+    testResultsFiles: '**\TEST-Result.xml'
+    testRunTitle: 'Mocha Test Run'

--- a/package.json
+++ b/package.json
@@ -251,6 +251,16 @@
           "type": "string",
           "default": null,
           "description": "Full path of browser to use"
+        },
+        "revealjs.exportHTMLPath": {
+          "type": "string",
+          "default": null,
+          "description": "Path where the HTML export is created, relative to the .md file"
+        },
+        "revealjs.openFilemanagerAfterHMLTExport": {
+          "type": "boolean",
+          "default": true,
+          "description": "Open the file manager after HTML export"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
           "default": null,
           "description": "Path where the HTML export is created, relative to the .md file"
         },
-        "revealjs.openFilemanagerAfterHMLTExport": {
+        "revealjs.openFilemanagerAfterHTMLExport": {
           "type": "boolean",
           "default": true,
           "description": "Open the file manager after HTML export"

--- a/src/ExportHTML.ts
+++ b/src/ExportHTML.ts
@@ -4,11 +4,12 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import { VSCodeRevealContext } from './VSCodeRevealContext'
 
-
-
 export const getExportFolderPath = (context: VSCodeRevealContext) => {
   const rootDir = path.dirname(context.editor.document.fileName)
-  const exportFolderName = path.basename(context.editor.document.fileName, '.md') + "-export"
+  let exportFolderName = path.basename(context.editor.document.fileName, '.md') + '-export'
+  if (context.extensionOptions.exportHTMLPath !== null && context.extensionOptions.exportHTMLPath !== '') {
+    exportFolderName = context.extensionOptions.exportHTMLPath
+  }
   return path.join(rootDir, exportFolderName)
 }
 

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -52,6 +52,8 @@ export interface IRevealJsOptions {
 export interface IExtensionOptions {
   slideExplorerEnabled: boolean
   browserPath: string
+  exportHTMLPath: string
+  openFilemanagerAfterHMLTExport: boolean
 }
 
 export interface ISlide {
@@ -60,4 +62,3 @@ export interface ISlide {
   text: string
   verticalChildren?: ISlide[] // Rem : child can't have child
 }
-

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -53,7 +53,7 @@ export interface IExtensionOptions {
   slideExplorerEnabled: boolean
   browserPath: string
   exportHTMLPath: string
-  openFilemanagerAfterHMLTExport: boolean
+  openFilemanagerAfterHTMLExport: boolean
 }
 
 export interface ISlide {

--- a/src/commands/exportHTML.ts
+++ b/src/commands/exportHTML.ts
@@ -28,7 +28,7 @@ export const exportHTML = (getContext: (() => VSCodeRevealContext)) => async () 
   }
   currentContext.SetInExportMode(() => {
     const path = getExportFolderPath(currentContext)
-    if (getExtensionOptions().openFilemanagerAfterHMLTExport) {
+    if (getExtensionOptions().openFilemanagerAfterHTMLExport) {
       opn(path)
     }
   })

--- a/src/commands/exportHTML.ts
+++ b/src/commands/exportHTML.ts
@@ -4,7 +4,7 @@ import { SHOW_REVEALJS_IN_BROWSER } from './showRevealJSInBrowser'
 import * as opn from 'opn'
 import { getExportFolderPath } from '../ExportHTML'
 import { openInBrowser } from '../BrowserHelper'
-import { getExtensionOptions } from '../Configuration';
+import { getExtensionOptions } from '../Configuration'
 
 export const EXPORT_HTML = 'vscode-revealjs.exportHTML'
 export type EXPORT_HTML = typeof EXPORT_HTML
@@ -27,7 +27,10 @@ export const exportHTML = (getContext: (() => VSCodeRevealContext)) => async () 
     return
   }
   currentContext.SetInExportMode(() => {
-    opn(getExportFolderPath(currentContext))
+    const path = getExportFolderPath(currentContext)
+    if (getExtensionOptions().openFilemanagerAfterHMLTExport) {
+      opn(path)
+    }
   })
   openInBrowser(getExtensionOptions(), currentContext.uri, true)
   openInBrowser(getExtensionOptions(), `${currentContext.server.uri}plugin/notes/notes.html`, true)


### PR DESCRIPTION
I want to have the html export in a different subfolder than the default and I don't want the file explorer to always open on export. Therefore I have added two new settings to enable that behavior but if those settings are unchanged, the extension works as before.

I don't know why GitHub shows the .ts files as completely changed, I only implemented the following changes:

src/Models.ts:
```
<<<
export interface IExtensionOptions {
  slideExplorerEnabled: boolean
  browserPath: string
}
---
export interface IExtensionOptions {
  slideExplorerEnabled: boolean
  browserPath: string
  exportHTMLPath: string
  openFilemanagerAfterHTMLExport: boolean
}
>>>
```


src/ExportHTML.ts;
```
<<<
export const getExportFolderPath = (context: VSCodeRevealContext) => {
  const rootDir = path.dirname(context.editor.document.fileName)
  const exportFolderName = path.basename(context.editor.document.fileName, '.md') + "-export"
  return path.join(rootDir, exportFolderName)
}
---
export const getExportFolderPath = (context: VSCodeRevealContext) => {
  const rootDir = path.dirname(context.editor.document.fileName)
  let exportFolderName = path.basename(context.editor.document.fileName, '.md') + '-export'
  if (context.extensionOptions.exportHTMLPath !== null && context.extensionOptions.exportHTMLPath !== '') {
    exportFolderName = context.extensionOptions.exportHTMLPath
  }
  return path.join(rootDir, exportFolderName)
}
>>>
```


src/commands/exportHTML.ts:
```
<<<
  currentContext.SetInExportMode(() => {
    opn(getExportFolderPath(currentContext))
  })
---
  currentContext.SetInExportMode(() => {
    const path = getExportFolderPath(currentContext)
    if (getExtensionOptions().openFilemanagerAfterHTMLExport) {
      opn(path)
    }
  })
>>>
```