### PR TITLE
Escape newline characters in separator config

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -91,8 +91,8 @@ export const defaultConfiguration: Configuration = {
   description: '',
   author: '',
   notesSeparator: 'note:',
-  separator: '^\r?\n---\r?\n$',
-  verticalSeparator: '^\r?\n--\r?\n$',
+  separator: '^\\r?\\n---\\r?\\n$',
+  verticalSeparator: '^\\r?\\n--\\r?\\n$',
 
   customHighlightTheme: null,
   customTheme: null,


### PR DESCRIPTION
This fixes #127 

The problem was the config value was escaping the `\r` and `\n` characters when templating them.