### PR TITLE
handle custom init in ESM format

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ enableSearch: false
 ---
 ```
 
+## Custom initialization (advanced)
+
+You can override revealjs initialization by putting `init.js` (or `init.esm.js` if you prefer ES module format). This gives you total control over executed code, but you'll have to call [Reveal.initialize()](https://revealjs.com/initialization/]) yourself. You also won't have access to frontmatter configuration, defaults, etc. Use at your own risk.
+
 ## <a id="faq"></a> FAQ
 
 

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -109,14 +109,20 @@ export class RevealServer extends Disposable {
     app.use((req, res, next) => {
       if (req.path !== '/') {
         next()
-      }
-      else {
-
-        let init: string | null = null;
+      } else {
+        let init: string | null = null
+        let initType: string | null = null
         if (context.dirname) {
           const initPath = path.join(context.dirname, 'init.js')
           if (fs.existsSync(initPath)) {
-            init = fs.readFileSync(initPath, "utf8");
+            init = fs.readFileSync(initPath, 'utf8')
+            initType = 'application/javascript'
+          } else {
+            const initPath = path.join(context.dirname, 'init.esm.js')
+            if (fs.existsSync(initPath)) {
+              init = fs.readFileSync(initPath, 'utf8')
+              initType = 'module'
+            }
           }
         }
 
@@ -125,8 +131,7 @@ export class RevealServer extends Disposable {
           html: markdownit.render(s.text),
           children: s.verticalChildren.map((c) => ({ ...c, html: markdownit.render(c.text) })),
         }))
-        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init })
-
+        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init, initType })
       }
     })
 

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -12,6 +12,7 @@ import { RevealContext } from './RevealContext'
 
 /** Http server to serve reveal presentation */
 export class RevealServer extends Disposable {
+
   public readonly app = express()
 
   private server: http.Server | null = null
@@ -21,6 +22,7 @@ export class RevealServer extends Disposable {
     super()
     this.configure()
   }
+
 
   /**
    * If the server is not listening, start the server and log the server's status.
@@ -56,7 +58,7 @@ export class RevealServer extends Disposable {
   /** Current uri for this server, empty is not listening */
   public get uri() {
     if (!this.isListening || this.server === null) {
-      return ''
+      return ""
     }
 
     const addr = this.server.address()
@@ -74,6 +76,8 @@ export class RevealServer extends Disposable {
     const app = this.app
     const context = this.context
 
+
+
     //disable cache
     app.set('etag', false)
     app.use((req, res, next) => {
@@ -82,9 +86,9 @@ export class RevealServer extends Disposable {
     })
 
     // Set EJS as view
-    app.set('view engine', 'ejs')
+    app.set('view engine', 'ejs');
     app.engine('ejs', ejs.__express)
-    app.set('views', path.resolve(context.extensionPath, 'views'))
+    app.set('views', path.resolve(context.extensionPath, 'views'));
     app.use(cors())
     // LOG REQUEST
     app.use(morgan(':method :url :status :res[content-length] - :response-time ms', { stream: { write: (str) => context.logger.info(str) } }))
@@ -94,23 +98,25 @@ export class RevealServer extends Disposable {
 
     // STATIC LIBS
     const libsPAth = path.join(context.extensionPath, 'libs')
-    app.use('/libs', express.static(libsPAth, { cacheControl: false, etag: false, immutable: false }))
+    app.use('/libs', express.static(libsPAth, { cacheControl: false, etag: false, immutable: false }));
 
     // STATIC RELATIVE TO MD FILE if file is saved
     if (context.dirname) {
-      app.use('/', express.static(context.dirname, { cacheControl: false, etag: false, immutable: false }))
+      app.use('/', express.static(context.dirname, { cacheControl: false, etag: false, immutable: false }));
     }
 
     // MAIN FILE
     app.use((req, res, next) => {
       if (req.path !== '/') {
         next()
-      } else {
+      }
+      else {
         let init: string | null = null
         let initType: string | null = null
         if (context.dirname) {
           let initPath = path.join(context.dirname, 'init.js')
           if (fs.existsSync(initPath)) {
+            init = fs.readFileSync(initPath, "utf8");
             init = fs.readFileSync(initPath, 'utf8')
             initType = 'application/javascript'
           }
@@ -119,7 +125,6 @@ export class RevealServer extends Disposable {
           if (!init && fs.existsSync(initPath)) {
             init = fs.readFileSync(initPath, 'utf8')
             initType = 'module'
-          }
         }
 
         const htmlSlides = context.slides.map((s) => ({
@@ -127,66 +132,75 @@ export class RevealServer extends Disposable {
           html: markdownit.render(s.text),
           children: s.verticalChildren.map((c) => ({ ...c, html: markdownit.render(c.text) })),
         }))
-        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init, initType })
+        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init })
+
       }
     })
 
     // ERROR HANDLER
     app.use(function (err, req, res, next) {
       context.logger.error(err.stack)
-      res.status(500).send(err.stack)
-    })
+      res.status(500).send(err.stack);
+    });
   }
 
   /* A middleware function that is used to export the presentation to a folder. */
   private readonly exportMiddleware = (exportfn: (ExportOptions) => Promise<void>, isInExport) => {
+
     const { exportPath } = this.context
 
     return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+
       if (isInExport()) {
-        console.log('in export')
+
+        console.log("in export");
         const oldWrite = res.write
-        const oldEnd = res.end
+        const oldEnd = res.end;
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const chunks: any[] = []
+        const chunks: any[] = [];
 
         res.write = (chunk, ...args) => {
-          chunks.push(chunk)
+          chunks.push(chunk);
           // @ts-ignore
-          return oldWrite.apply(res, [chunk, ...args])
-        }
+          return oldWrite.apply(res, [chunk, ...args]);
+        };
         // @ts-ignore
         res.end = async (chunk, ...args) => {
           this.context.logger.info(`${req.originalUrl.split('?')[0]} - ${chunks.length}`)
           if (chunk) {
-            chunks.push(chunk)
+            chunks.push(chunk);
           }
           try {
-            let body = ''
+            let body = "";
             if (chunks.length > 0 && typeof chunks[0] === 'string') {
-              body = body.concat(...(chunks as string[]))
-            } else {
-              body = Buffer.concat(chunks).toString('utf8')
+              body = body.concat(...(chunks as string[]));
+            }
+            else {
+              body = Buffer.concat(chunks).toString('utf8');
             }
 
+
             const opts: IExportOptions = { folderPath: exportPath, url: req.originalUrl.split('?')[0], srcFilePath: null, data: body }
-            await exportfn(opts)
-          } catch (error) {
+            await exportfn(opts);
+          }
+          catch (error) {
             this.context.logger.info(`Error : ${error}`)
           }
 
           // @ts-ignore
-          return oldEnd.apply(res, [chunk, ...args])
-        }
+          return oldEnd.apply(res, [chunk, ...args]);
+        };
       }
       next()
+
+
     }
   }
 
   dispose(): void {
     this.stop()
     this.server = null
-    super.dispose()
+    super.dispose();
   }
 }

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -18,7 +18,7 @@
 		const plugins =  [...printPlugins,
 		<% if(enableZoom) {%>RevealZoom, <%}%>
 		<% if(enableSearch) {%>RevealSearch, <%}%>
-				RevealMarkdown, 
+				RevealMarkdown,
 				<% if(enableMenu) {%>RevealMenu, <%}%>
 				RevealFullscreen,
 				RevealAnything,
@@ -28,7 +28,7 @@
 				// poll
 				// question
 				// seminar
-				Verticator 
+				Verticator
 				 ]
 
 
@@ -148,18 +148,18 @@
 				]
 			},
 			chart: {
-					defaults: { 
+					defaults: {
 						color: 'lightgray', // color of labels
-						scale: { 
-							beginAtZero: true, 
+						scale: {
+							beginAtZero: true,
 							ticks: { stepSize: 1 },
 							grid: { color: "lightgray" } , // color of grid lines
 						},
 					},
-					line: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ], "borderDash": [ [5,10], [0,0] ] }, 
-					bar: { backgroundColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]}, 
+					line: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ], "borderDash": [ [5,10], [0,0] ] },
+					bar: { backgroundColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]},
 					pie: { backgroundColor: [ ["rgba(0,0,0,.8)" , "rgba(220,20,20,.8)", "rgba(20,220,20,.8)", "rgba(220,220,20,.8)", "rgba(20,20,220,.8)"] ]},
-					radar: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]}, 
+					radar: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]},
 			},
 			math: {
 				mathjax: 'https://cdn.jsdelivr.net/gh/mathjax/mathjax@2.7.8/MathJax.js',
@@ -167,14 +167,14 @@
 				// pass other options into `MathJax.Hub.Config()`
 				TeX: { Macros: { RR: "{\\bf R}" } }
 				},
-				anything: [ 
+				anything: [
 				{
 		className: "plot",
 		defaults: {width:500, height: 500, grid:true},
 		initialize: (function(container, options){ options.target = "#"+container.id; functionPlot(options) })
 	 },
 	 {
-		className: "chart",  
+		className: "chart",
 		initialize: (function(container, options){ container.chart = new Chart(container.getContext("2d"), options);  })
 	 },
 	 {
@@ -183,12 +183,12 @@
 	 },
 					],
 			// Learn about plugins: https://revealjs.com/plugins/
-			plugins: (window.location.search.match(/print-pdf/gi) ? printPlugins : plugins ) 
+			plugins: (window.location.search.match(/print-pdf/gi) ? printPlugins : plugins )
 		});
-			
 
 
-	    // Change chalkboard theme : 
+
+	    // Change chalkboard theme :
 		function changeTheme(input) {
 			var config = {};
 			config.theme = input.value;
@@ -211,7 +211,7 @@
       		setTimeout(() => {
 				window.print();
 			  }, 2500);
-			
+
     }
 </script>
 <%}%>

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -1,5 +1,5 @@
 <% if(init) { %>
-<script>
+<script type="<%- initType %>">
   <%- init %>
 </script>
 <%}else{ %>


### PR DESCRIPTION
Custom init script is very useful, but it lacked the support for module type scripts. 
Modules make it possible to import other files, so you don't have to put all the code into init.js.

This PR adds handling of `init.esm.js` script as type=module.