### PR TITLE
Expose revealOptions to init.js

### DIFF
--- a/views/init.ejs
+++ b/views/init.ejs
@@ -1,193 +1,194 @@
+<script>
+  const revealOptions = () => {
+    const printPlugins = [
+        RevealNotes,
+        RevealHighlight,
+        RevealMath.MathJax3,
+        RevealAnimate,
+        <% if(enableChalkboard) {%>RevealChalkboard, <%}%>
+        RevealEmbedTweet,
+        RevealChart,
+      ];
+  
+      const plugins =  [...printPlugins,
+      <% if(enableZoom) {%>RevealZoom, <%}%>
+      <% if(enableSearch) {%>RevealSearch, <%}%>
+          RevealMarkdown, 
+          <% if(enableMenu) {%>RevealMenu, <%}%>
+          RevealFullscreen,
+          RevealAnything,
+          //RevealAudioSlideshow,
+          //RevealAudioRecorder,
+          <% if(enableMenu) {%>RevealCustomControls, <%}%>
+          // poll
+          // question
+          // seminar
+          Verticator 
+           ]
+  
+  
+      // Also available as an ES module, see:
+      // https://revealjs.com/initialization/
+      return {
+        controls: <%= controls %>,
+        controlsTutorial: <%= controlsTutorial %>,
+        controlsLayout: '<%= controlsLayout %>',
+        controlsBackArrows: '<%= controlsBackArrows %>',
+        progress: <%= progress %>,
+        slideNumber: <%= slideNumber %>,
+        //#showSlideNumber "all" "print" "speaker"
+        hash: true, //# hash: false,
+        //# respondToHashChanges: true,
+        //# history: false,
+        keyboard: <%= keyboard %>,
+        //#keyboardCondition: null,
+        overview: <%= overview %>,
+        center: <%= center %>,
+        touch: <%= touch %>,
+        loop: <%= loop %>,
+        rtl: <%= rtl %>,
+        //#navigationMode: 'default', linear grid
+        shuffle: <%= shuffle %>,
+        fragments: <%= fragments %>,
+        fragmentInURL: <%= fragmentInURL %>,
+        embedded: <%= embedded %>,
+        help: <%= help %>,
+        //#pause: true
+        showNotes: <%= showNotes %>,
+        autoPlayMedia: <%= autoPlayMedia %>, // TODO fix this to a nullable value
+        //#preloadIframes: null. true false
+        //#autoAnimate: true
+        //#autoAnimateMatcher: null,
+        //#autoAnimateEasing: 'ease',
+        //autoAnimateDuration: 1.0,
+        //#autoAnimateUnmatched: true
+        //#autoAnimateStyles: []
+        autoSlide: <%= autoSlide %>, // TODO fix this to a falseable value
+        autoSlideStoppable: <%= autoSlideStoppable %>,
+        autoSlideMethod: '<%= autoSlide %>',
+        defaultTiming: <%= defaultTiming %>,
+        mouseWheel: <%= mouseWheel %>,
+        //#previewLinks: false
+        //#postMessage: true, // TODO : this can cause issues with the vscode api ???
+        //#postMessageEvents: false,
+        //#focusBodyOnPageVisibilityChange: true,
+        transition: '<%= transition %>',
+        transitionSpeed: '<%= transitionSpeed %>',
+        backgroundTransition: '<%= backgroundTransition %>',
+        //#pdfMaxPagesPerSlide: Number.POSITIVE_INFINITY,
+        //#pdfSeparateFragments: true,
+        //#pdfPageHeightOffset: -1,
+        viewDistance: <%= viewDistance %>,
+        //#mobileViewDistance: 2,
+        display: '<%= display %>',
+        //#hideInactiveCursor: true,
+        //#hideCursorTime: 5000
+  
+        // Parallax Background
+        parallaxBackgroundImage: '<%= parallaxBackgroundImage %>',
+        parallaxBackgroundSize: '<%= parallaxBackgroundSize %>',
+        parallaxBackgroundHorizontal: <%= parallaxBackgroundHorizontal %>,
+        parallaxBackgroundVertical: <%= parallaxBackgroundVertical %>,
+  
+        //Presentation Size
+        width: <% if (isNaN(width)) { %> '<%= width %>'
+        <% } else{ %><%= width %><%}%>,
+        height: <% if (isNaN(height)) { %> '<%= height %>'
+        <% } else{ %><%= height %><%}%>,
+        margin: <%= margin %>,
+        minScale: <%= minScale %>,
+        maxScale: <%= maxScale %>,
+        disableLayout: <%= disableLayout %>,
+  
+        audio: {
+          prefix: 'audio/', // audio files are stored in the "audio" folder
+          suffix: '.ogg', // audio files have the ".ogg" ending
+          textToSpeechURL: null, // the URL to the text to speech converter
+          defaultNotes: false, // use slide notes as default for the text to speech converter
+          defaultText: false, // use slide text as default for the text to speech converter
+          advance: 0, // advance to next slide after given time in milliseconds after audio has played, use negative value to not advance
+          autoplay: false, // automatically start slideshow
+          defaultDuration: 5, // default duration in seconds if no audio is available
+          defaultAudios: true, // try to play audios with names such as audio/1.2.ogg
+          playerOpacity: 0.05, // opacity value of audio player if unfocused
+          playerStyle: 'position: fixed; bottom: 4px; left: 25%; width: 50%; height:75px; z-index: 33;', // style used for container of audio controls
+          startAtFragment: false, // when moving to a slide, start at the current fragment or at the start of the slide
+        },
+        <% if(enableChalkboard) {%>
+        chalkboard: { // font-awesome.min.css must be available
+          //src: "chalkboard/chalkboard.json",
+          storage: "chalkboard-demo",
+        },
+        <%}%>
+        customcontrols: {
+            controls: [
+                    {
+                id: 'toggle-overview',
+                title: 'Toggle overview (O)',
+                icon: '<i class="fa fa-th"></i>',
+                action: 'Reveal.toggleOverview();'
+              }
+              <% if(enableChalkboard) {%>,
+        {
+          icon: '<i class="fa fa-pen-square"></i>',
+          title: 'Toggle chalkboard (B)',
+          action: 'RevealChalkboard.toggleChalkboard();'
+        },
+        {
+          icon: '<i class="fa fa-pen"></i>',
+          title: 'Toggle notes canvas (C)',
+          action: 'RevealChalkboard.toggleNotesCanvas();'
+        }
+        <%}%>
+          ]
+        },
+        chart: {
+            defaults: { 
+              color: 'lightgray', // color of labels
+              scale: { 
+                beginAtZero: true, 
+                ticks: { stepSize: 1 },
+                grid: { color: "lightgray" } , // color of grid lines
+              },
+            },
+            line: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ], "borderDash": [ [5,10], [0,0] ] }, 
+            bar: { backgroundColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]}, 
+            pie: { backgroundColor: [ ["rgba(0,0,0,.8)" , "rgba(220,20,20,.8)", "rgba(20,220,20,.8)", "rgba(220,220,20,.8)", "rgba(20,20,220,.8)"] ]},
+            radar: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]}, 
+        },
+        math: {
+          mathjax: 'https://cdn.jsdelivr.net/gh/mathjax/mathjax@2.7.8/MathJax.js',
+          config: 'TeX-AMS_HTML-full',
+          // pass other options into `MathJax.Hub.Config()`
+          TeX: { Macros: { RR: "{\\bf R}" } }
+          },
+          anything: [ 
+          {
+      className: "plot",
+      defaults: {width:500, height: 500, grid:true},
+      initialize: (function(container, options){ options.target = "#"+container.id; functionPlot(options) })
+     },
+     {
+      className: "chart",  
+      initialize: (function(container, options){ container.chart = new Chart(container.getContext("2d"), options);  })
+     },
+     {
+      className: "anything",
+      initialize: (function(container, options){ if (options && options.initialize) { options.initialize(container)} })
+     },
+            ],
+        // Learn about plugins: https://revealjs.com/plugins/
+        plugins: (window.location.search.match(/print-pdf/gi) ? printPlugins : plugins ) 
+      };
+  }
+</script>  
 <% if(init) { %>
 <script>
   <%- init %>
 </script>
 <%}else{ %>
-
 <script>
-  const printPlugins = [
-      RevealNotes,
-      RevealHighlight,
-      RevealMath.MathJax3,
-      RevealAnimate,
-      <% if(enableChalkboard) {%>RevealChalkboard, <%}%>
-			RevealEmbedTweet,
-			RevealChart,
-		];
-
-		const plugins =  [...printPlugins,
-		<% if(enableZoom) {%>RevealZoom, <%}%>
-		<% if(enableSearch) {%>RevealSearch, <%}%>
-				RevealMarkdown, 
-				<% if(enableMenu) {%>RevealMenu, <%}%>
-				RevealFullscreen,
-				RevealAnything,
-				//RevealAudioSlideshow,
-				//RevealAudioRecorder,
-				<% if(enableMenu) {%>RevealCustomControls, <%}%>
-				// poll
-				// question
-				// seminar
-				Verticator 
-				 ]
-
-
-		// Also available as an ES module, see:
-		// https://revealjs.com/initialization/
-		Reveal.initialize({
-			controls: <%= controls %>,
-      controlsTutorial: <%= controlsTutorial %>,
-      controlsLayout: '<%= controlsLayout %>',
-      controlsBackArrows: '<%= controlsBackArrows %>',
-      progress: <%= progress %>,
-      slideNumber: <%= slideNumber %>,
-      //#showSlideNumber "all" "print" "speaker"
-      hash: true, //# hash: false,
-      //# respondToHashChanges: true,
-      //# history: false,
-      keyboard: <%= keyboard %>,
-      //#keyboardCondition: null,
-      overview: <%= overview %>,
-      center: <%= center %>,
-      touch: <%= touch %>,
-      loop: <%= loop %>,
-      rtl: <%= rtl %>,
-      //#navigationMode: 'default', linear grid
-      shuffle: <%= shuffle %>,
-      fragments: <%= fragments %>,
-      fragmentInURL: <%= fragmentInURL %>,
-      embedded: <%= embedded %>,
-      help: <%= help %>,
-      //#pause: true
-      showNotes: <%= showNotes %>,
-      autoPlayMedia: <%= autoPlayMedia %>, // TODO fix this to a nullable value
-      //#preloadIframes: null. true false
-      //#autoAnimate: true
-      //#autoAnimateMatcher: null,
-      //#autoAnimateEasing: 'ease',
-      //autoAnimateDuration: 1.0,
-      //#autoAnimateUnmatched: true
-      //#autoAnimateStyles: []
-      autoSlide: <%= autoSlide %>, // TODO fix this to a falseable value
-      autoSlideStoppable: <%= autoSlideStoppable %>,
-      autoSlideMethod: '<%= autoSlide %>',
-      defaultTiming: <%= defaultTiming %>,
-      mouseWheel: <%= mouseWheel %>,
-      //#previewLinks: false
-      //#postMessage: true, // TODO : this can cause issues with the vscode api ???
-      //#postMessageEvents: false,
-      //#focusBodyOnPageVisibilityChange: true,
-      transition: '<%= transition %>',
-      transitionSpeed: '<%= transitionSpeed %>',
-      backgroundTransition: '<%= backgroundTransition %>',
-      //#pdfMaxPagesPerSlide: Number.POSITIVE_INFINITY,
-      //#pdfSeparateFragments: true,
-      //#pdfPageHeightOffset: -1,
-      viewDistance: <%= viewDistance %>,
-      //#mobileViewDistance: 2,
-      display: '<%= display %>',
-      //#hideInactiveCursor: true,
-      //#hideCursorTime: 5000
-
-      // Parallax Background
-      parallaxBackgroundImage: '<%= parallaxBackgroundImage %>',
-      parallaxBackgroundSize: '<%= parallaxBackgroundSize %>',
-      parallaxBackgroundHorizontal: <%= parallaxBackgroundHorizontal %>,
-      parallaxBackgroundVertical: <%= parallaxBackgroundVertical %>,
-
-      //Presentation Size
-      width: <% if (isNaN(width)) { %> '<%= width %>'
-      <% } else{ %><%= width %><%}%>,
-			height: <% if (isNaN(height)) { %> '<%= height %>'
-      <% } else{ %><%= height %><%}%>,
-			margin: <%= margin %>,
-      minScale: <%= minScale %>,
-      maxScale: <%= maxScale %>,
-      disableLayout: <%= disableLayout %>,
-
-      audio: {
-        prefix: 'audio/', // audio files are stored in the "audio" folder
-        suffix: '.ogg', // audio files have the ".ogg" ending
-        textToSpeechURL: null, // the URL to the text to speech converter
-        defaultNotes: false, // use slide notes as default for the text to speech converter
-        defaultText: false, // use slide text as default for the text to speech converter
-        advance: 0, // advance to next slide after given time in milliseconds after audio has played, use negative value to not advance
-        autoplay: false, // automatically start slideshow
-        defaultDuration: 5, // default duration in seconds if no audio is available
-        defaultAudios: true, // try to play audios with names such as audio/1.2.ogg
-        playerOpacity: 0.05, // opacity value of audio player if unfocused
-        playerStyle: 'position: fixed; bottom: 4px; left: 25%; width: 50%; height:75px; z-index: 33;', // style used for container of audio controls
-        startAtFragment: false, // when moving to a slide, start at the current fragment or at the start of the slide
-      },
-      <% if(enableChalkboard) {%>
-      chalkboard: { // font-awesome.min.css must be available
-        //src: "chalkboard/chalkboard.json",
-        storage: "chalkboard-demo",
-      },
-      <%}%>
-			customcontrols: {
-					controls: [
-      						{
-						  id: 'toggle-overview',
-						  title: 'Toggle overview (O)',
-						  icon: '<i class="fa fa-th"></i>',
-						  action: 'Reveal.toggleOverview();'
-						}
-						<% if(enableChalkboard) {%>,
-      {
-        icon: '<i class="fa fa-pen-square"></i>',
-        title: 'Toggle chalkboard (B)',
-        action: 'RevealChalkboard.toggleChalkboard();'
-      },
-      {
-        icon: '<i class="fa fa-pen"></i>',
-        title: 'Toggle notes canvas (C)',
-        action: 'RevealChalkboard.toggleNotesCanvas();'
-      }
-      <%}%>
-				]
-			},
-			chart: {
-					defaults: { 
-						color: 'lightgray', // color of labels
-						scale: { 
-							beginAtZero: true, 
-							ticks: { stepSize: 1 },
-							grid: { color: "lightgray" } , // color of grid lines
-						},
-					},
-					line: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ], "borderDash": [ [5,10], [0,0] ] }, 
-					bar: { backgroundColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]}, 
-					pie: { backgroundColor: [ ["rgba(0,0,0,.8)" , "rgba(220,20,20,.8)", "rgba(20,220,20,.8)", "rgba(220,220,20,.8)", "rgba(20,20,220,.8)"] ]},
-					radar: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]}, 
-			},
-			math: {
-				mathjax: 'https://cdn.jsdelivr.net/gh/mathjax/mathjax@2.7.8/MathJax.js',
-				config: 'TeX-AMS_HTML-full',
-				// pass other options into `MathJax.Hub.Config()`
-				TeX: { Macros: { RR: "{\\bf R}" } }
-				},
-				anything: [ 
-				{
-		className: "plot",
-		defaults: {width:500, height: 500, grid:true},
-		initialize: (function(container, options){ options.target = "#"+container.id; functionPlot(options) })
-	 },
-	 {
-		className: "chart",  
-		initialize: (function(container, options){ container.chart = new Chart(container.getContext("2d"), options);  })
-	 },
-	 {
-		className: "anything",
-		initialize: (function(container, options){ if (options && options.initialize) { options.initialize(container)} })
-	 },
-					],
-			// Learn about plugins: https://revealjs.com/plugins/
-			plugins: (window.location.search.match(/print-pdf/gi) ? printPlugins : plugins ) 
-		});
-			
-
-
+    Reveal.initialize(revealOptions());
 	    // Change chalkboard theme : 
 		function changeTheme(input) {
 			var config = {};

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -9,11 +9,11 @@
         RevealEmbedTweet,
         RevealChart,
       ];
-  
+
       const plugins =  [...printPlugins,
       <% if(enableZoom) {%>RevealZoom, <%}%>
       <% if(enableSearch) {%>RevealSearch, <%}%>
-          RevealMarkdown, 
+          RevealMarkdown,
           <% if(enableMenu) {%>RevealMenu, <%}%>
           RevealFullscreen,
           RevealAnything,
@@ -23,10 +23,10 @@
           // poll
           // question
           // seminar
-          Verticator 
+          Verticator
            ]
-  
-  
+
+
       // Also available as an ES module, see:
       // https://revealjs.com/initialization/
       return {
@@ -83,13 +83,13 @@
         display: '<%= display %>',
         //#hideInactiveCursor: true,
         //#hideCursorTime: 5000
-  
+
         // Parallax Background
         parallaxBackgroundImage: '<%= parallaxBackgroundImage %>',
         parallaxBackgroundSize: '<%= parallaxBackgroundSize %>',
         parallaxBackgroundHorizontal: <%= parallaxBackgroundHorizontal %>,
         parallaxBackgroundVertical: <%= parallaxBackgroundVertical %>,
-  
+
         //Presentation Size
         width: <% if (isNaN(width)) { %> '<%= width %>'
         <% } else{ %><%= width %><%}%>,
@@ -99,7 +99,7 @@
         minScale: <%= minScale %>,
         maxScale: <%= maxScale %>,
         disableLayout: <%= disableLayout %>,
-  
+
         audio: {
           prefix: 'audio/', // audio files are stored in the "audio" folder
           suffix: '.ogg', // audio files have the ".ogg" ending
@@ -143,18 +143,18 @@
           ]
         },
         chart: {
-            defaults: { 
+            defaults: {
               color: 'lightgray', // color of labels
-              scale: { 
-                beginAtZero: true, 
+              scale: {
+                beginAtZero: true,
                 ticks: { stepSize: 1 },
                 grid: { color: "lightgray" } , // color of grid lines
               },
             },
-            line: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ], "borderDash": [ [5,10], [0,0] ] }, 
-            bar: { backgroundColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]}, 
+            line: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ], "borderDash": [ [5,10], [0,0] ] },
+            bar: { backgroundColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]},
             pie: { backgroundColor: [ ["rgba(0,0,0,.8)" , "rgba(220,20,20,.8)", "rgba(20,220,20,.8)", "rgba(220,220,20,.8)", "rgba(20,20,220,.8)"] ]},
-            radar: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]}, 
+            radar: { borderColor: [ "rgba(20,220,220,.8)" , "rgba(220,120,120,.8)", "rgba(20,120,220,.8)" ]},
         },
         math: {
           mathjax: 'https://cdn.jsdelivr.net/gh/mathjax/mathjax@2.7.8/MathJax.js',
@@ -162,14 +162,14 @@
           // pass other options into `MathJax.Hub.Config()`
           TeX: { Macros: { RR: "{\\bf R}" } }
           },
-          anything: [ 
+          anything: [
           {
       className: "plot",
       defaults: {width:500, height: 500, grid:true},
       initialize: (function(container, options){ options.target = "#"+container.id; functionPlot(options) })
      },
      {
-      className: "chart",  
+      className: "chart",
       initialize: (function(container, options){ container.chart = new Chart(container.getContext("2d"), options);  })
      },
      {
@@ -178,10 +178,10 @@
      },
             ],
         // Learn about plugins: https://revealjs.com/plugins/
-        plugins: (window.location.search.match(/print-pdf/gi) ? printPlugins : plugins ) 
+        plugins: (window.location.search.match(/print-pdf/gi) ? printPlugins : plugins )
       };
   }
-</script>  
+</script>
 <% if(init) { %>
 <script>
   <%- init %>
@@ -189,7 +189,7 @@
 <%}else{ %>
 <script>
     Reveal.initialize(revealOptions());
-	    // Change chalkboard theme : 
+	    // Change chalkboard theme :
 		function changeTheme(input) {
 			var config = {};
 			config.theme = input.value;
@@ -212,7 +212,7 @@
       		setTimeout(() => {
 				window.print();
 			  }, 2500);
-			
+
     }
 </script>
 <%}%>


### PR DESCRIPTION
Move creation of reveal options to `revealOptions` function. Add this function before embedding `init.js`.
This will give custom initialization code access to the options object created by the vscode-reveal. This way, any configuration done in frontmatter, default plugins, etc. can still work and be further customized when using `init.js`.