### PR TITLE
feat: add open in vscode/browser commands to right click context menu…

### DIFF
--- a/package.json
+++ b/package.json
@@ -570,8 +570,7 @@
           "command": "vscode-revealjs.showRevealJSInBrowser",
           "group": "navigation"
         }
-  ]
-    
+      ]
     },
     "snippets": [
       {

--- a/package.json
+++ b/package.json
@@ -541,12 +541,37 @@
           "group": "navigation"
         }
       ],
+      "editor/title": [
+        {
+          "when": "resourceLangId == markdown",
+          "command": "vscode-revealjs.showRevealJS",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == markdown",
+          "command": "vscode-revealjs.showRevealJSInBrowser",
+          "group": "navigation"
+        }
+      ],
       "view/item/context": [
         {
           "command": "vscode-revealjs.goToSlide",
           "when": "view == slidesExplorer && viewItem == slideNode"
         }
-      ]
+      ],
+      "explorer/context": [
+        {
+          "when": "resourceLangId == markdown",
+          "command": "vscode-revealjs.showRevealJS",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == markdown",
+          "command": "vscode-revealjs.showRevealJSInBrowser",
+          "group": "navigation"
+        }
+  ]
+    
     },
     "snippets": [
       {


### PR DESCRIPTION
… and editor title when file is markdown.

This PR adds the open commands in the right click context menu and the editor title area for markdown files. This means it's easier to open presentations from the explorer without using the VSCode Reveal sidebar or the command palette.

Context menu:
![Code-2024-02-16-14-59-Code_HX7YLc8pFD](https://github.com/evilz/vscode-reveal/assets/110549389/8a2bcab1-5516-4930-9fe8-0026fbc3e503)

Editor title area:
![Code-2024-02-16-14-59-Code_lF5z5zqLWI](https://github.com/evilz/vscode-reveal/assets/110549389/4013c9fa-9925-4311-93e8-c0d1f236b3ab)
