### PR TITLE
fix: prevent binary file corruption during slide export

### DIFF
--- a/src/ExportHTML.ts
+++ b/src/ExportHTML.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 export interface IExportOptions {
   folderPath: string,
   url: string,
-  data: string | null
+  data: string | Buffer | null
   srcFilePath: string | null
 }
 

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -173,7 +173,7 @@ export class RevealServer extends Disposable {
               body = Buffer.concat(chunks);
             }
 
-            
+
             const opts: IExportOptions = { folderPath: exportPath, url: req.originalUrl.split('?')[0], srcFilePath: null, data: body }
             await exportfn(opts);
           }

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -165,15 +165,15 @@ export class RevealServer extends Disposable {
             chunks.push(chunk);
           }
           try {
-            let body = "";
+            let body: string | Buffer;
             if (chunks.length > 0 && typeof chunks[0] === 'string') {
-              body = body.concat(...(chunks as string[]));
+              body = "".concat(...(chunks as string[]));
             }
             else {
-              body = Buffer.concat(chunks).toString('utf8');
+              body = Buffer.concat(chunks);
             }
 
-
+            
             const opts: IExportOptions = { folderPath: exportPath, url: req.originalUrl.split('?')[0], srcFilePath: null, data: body }
             await exportfn(opts);
           }


### PR DESCRIPTION
This is addressing this issue : https://github.com/evilz/vscode-reveal/issues/1029 