### PR TITLE
Fix typo in quick-start docs

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -11,6 +11,6 @@ You can click on it to display a preview in a side tab.
 
 It will start a webserver in background and the statusbar will display the server address and a button to stop it.
 
-![stqtusbar](assets/images/statusbar.png)
+![statusbar](assets/images/statusbar.png)
 
 If you click on the server address it will open the presentation in your default browser.


### PR DESCRIPTION
## Summary
- fix link alt text for statusbar image

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a0ffc9cc832cbb8d904a7f8d6190