### PR TITLE
Dispose WebViewPane resources correctly

### DIFF
--- a/src/WebViewPane.ts
+++ b/src/WebViewPane.ts
@@ -71,6 +71,7 @@ export default class WebviewPane
       // }, null)
   
     public dispose() {
-        this.#onDidDispose.fire()
+        this.#onDidDispose.fire();
+        super.dispose();
     }
 }


### PR DESCRIPTION
## Summary
- ensure WebViewPane fires its dispose event before calling base disposal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c1f45d48832ca1efa0b251164acc