### PR TITLE
chore: register SlideTreeProvider

### DIFF
--- a/src/SlideExplorer.ts
+++ b/src/SlideExplorer.ts
@@ -34,7 +34,9 @@ export class SlideTreeProvider extends Disposable
   }
 
   public register() {
-    return vscode.window.registerTreeDataProvider('slidesExplorer', this)
+    return this._register(
+      vscode.window.registerTreeDataProvider('slidesExplorer', this)
+    )
   }
 
   public getTreeItem(element: SlideNode): vscode.TreeItem | Thenable<vscode.TreeItem> {

--- a/src/test/UnitTests/SlideExplorer.jest.ts
+++ b/src/test/UnitTests/SlideExplorer.jest.ts
@@ -1,0 +1,16 @@
+import { SlideTreeProvider } from "../../SlideExplorer";
+import * as vscode from "vscode";
+
+test('dispose cleans up registered provider', () => {
+  const dispose = jest.fn();
+  const registration = { dispose } as vscode.Disposable;
+  const spy = jest.spyOn(vscode.window, 'registerTreeDataProvider').mockReturnValue(registration);
+
+  const provider = new SlideTreeProvider(() => []);
+  provider.register();
+  provider.dispose();
+
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(dispose).toHaveBeenCalledTimes(1);
+  spy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- register slide explorer tree provider with dispose tracking
- test cleanup of SlideTreeProvider registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899c24abe40832cb4800d45cff36896