### PR TITLE
Allow numeric configuration descriptions

### DIFF
--- a/src/CompletionItemProvider.ts
+++ b/src/CompletionItemProvider.ts
@@ -66,6 +66,8 @@ export const createCompletionItems = (configDesc: ConfigurationDescription[]) =>
         case 'boolean':
           enumValueProviders.push(enumValueProvider(label, ['true', 'false']))
           break
+        case 'number':
+          break
       }
 
       completionItem.commitCharacters = [' ']

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -173,7 +173,7 @@ export const defaultConfiguration: Configuration = {
 }
 
 
-type ConfigurationDescriptionTypes = "string" | "boolean"
+type ConfigurationDescriptionTypes = "string" | "boolean" | "number"
 export interface ConfigurationDescription {
   label: string,
   detail: string,

--- a/src/test/UnitTests/CompletionItemProvider.jest.ts
+++ b/src/test/UnitTests/CompletionItemProvider.jest.ts
@@ -66,4 +66,18 @@ test('Should createCompletionItems from configDesc', () => {
     expect(completion).toStrictEqual([new CompletionItem("test_values")])
 });
 
+test('Should handle number type without enum provider', () => {
+    const configDesc: ConfigurationDescription = {
+        label: 'num_option',
+        detail: 'numeric detail',
+        documentation: 'doc',
+        type: 'number'
+    }
+
+    const { completionItems, enumValueProviders } = createCompletionItems([configDesc])
+
+    expect(completionItems).toHaveLength(1)
+    expect(enumValueProviders).toHaveLength(0)
+})
+
 


### PR DESCRIPTION
## Summary
- allow "number" in ConfigurationDescriptionTypes and completion handling
- test completion provider with numeric configuration descriptions

## Testing
- `npm run test-compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c25da9a4832ca9060a137afd262b