### PR TITLE
refactor: use slice instead of substr

### DIFF
--- a/src/SlideParser.ts
+++ b/src/SlideParser.ts
@@ -3,13 +3,13 @@ import { ISlide } from './ISlide';
 import { Disposable } from './dispose';
 import frontmatter, { FrontMatterResult } from 'front-matter'
 
-const trimFirstLastEmptyLine = (s) => {
+const trimFirstLastEmptyLine = (s: string): string => {
   let content = s
-  content = content.indexOf("\n") === 0 ? content.substr(1) : content
-  content = content.indexOf("\r\n") === 0 ? content.substr(2) : content
+  content = content.indexOf("\n") === 0 ? content.slice(1) : content
+  content = content.indexOf("\r\n") === 0 ? content.slice(2) : content
 
-  content = content.lastIndexOf("\n") === content.length - 1 ? content.substr(0, content.length - 1) : content
-  content = content.lastIndexOf("\r\n") === content.length - 2 ? content.substr(0, content.length - 2) : content
+  content = content.lastIndexOf("\n") === content.length - 1 ? content.slice(0, content.length - 1) : content
+  content = content.lastIndexOf("\r\n") === content.length - 2 ? content.slice(0, content.length - 2) : content
   return content
 }
 


### PR DESCRIPTION
## Summary
- type trimFirstLastEmptyLine helper and replace deprecated `substr` calls with `slice`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899c280b4f0832c8fd0903e6232938c