### PR TITLE
Add StatusBarController dispose test

### DIFF
--- a/src/test/UnitTests/StatusBarController.jest.ts
+++ b/src/test/UnitTests/StatusBarController.jest.ts
@@ -1,0 +1,15 @@
+import { window } from 'vscode';
+import { StatusBarController } from '../../StatusBarController';
+
+test('dispose disposes all status bar items', () => {
+  jest.clearAllMocks();
+
+  const controller = new StatusBarController();
+  controller.dispose();
+
+  const items = (window.createStatusBarItem as jest.Mock).mock.results.map(r => r.value);
+  items.forEach(item => {
+    expect(item.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -156,9 +156,9 @@ export interface DecorationRenderOptions extends ThemableDecorationRenderOptions
 
 export namespace window {
 
-  export function createStatusBarItem(alignment?: StatusBarAlignment, priority?: number): StatusBarItem {
-    return { hide: () => { } } as StatusBarItem;
-  }
+  export const createStatusBarItem = jest.fn((alignment?: StatusBarAlignment, priority?: number): StatusBarItem => {
+    return { hide: jest.fn(), dispose: jest.fn() } as unknown as StatusBarItem;
+  });
 
   export function createTextEditorDecorationType(options: DecorationRenderOptions): TextEditorDecorationType {
     return {} as TextEditorDecorationType;


### PR DESCRIPTION
## Summary
- mock status bar item disposal in VS Code test doubles
- add unit test ensuring StatusBarController disposes all status bar items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899e087d438832c90539fe489ce9887