### PR TITLE
Add 'New presentation from template' command and scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ transition: "zoom"
 > Note do not add `revealjs.` prefix before setting name.
 
 
+## Create a new presentation
+
+You can scaffold a new presentation directly from built-in templates:
+- run the command `Revealjs: New presentation from template`
+- choose a starter template (`Minimal`, `Code-heavy`, `Speaker notes`, or `Custom theme`)
+- pick where to save the `.md` file
+
+When a template needs local assets (for example `Custom theme`), the extension creates only the required supporting files next to your presentation.
+
 ## <a id="preview"></a> Open preview on right side
 
 To display the preview on the right side you can :

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "onLanguage:markdown",
     "onCommand:vscode-revealjs.showSample",
     "onCommand:vscode-revealjs.showRevealJS",
-    "onCommand:vscode-revealjs.showRevealJSInBrowser"
+    "onCommand:vscode-revealjs.showRevealJSInBrowser",
+    "onCommand:vscode-revealjs.newPresentation"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -91,6 +92,10 @@
           "light": "resources/light/html.svg",
           "dark": "resources/dark/html.svg"
         }
+      },
+      {
+        "command": "vscode-revealjs.newPresentation",
+        "title": "Revealjs: New presentation from template"
       }
     ],
     "configuration": {

--- a/src/commands/newPresentation.ts
+++ b/src/commands/newPresentation.ts
@@ -73,7 +73,7 @@ export const createPresentationFromTemplate = async () => {
   }
 
   const workspaceFolder = workspace.workspaceFolders?.[0]
-  const defaultUri = workspaceFolder ? Uri.file(path.join(workspaceFolder.uri.fsPath, 'presentation.md')) : undefined
+  const defaultUri = workspaceFolder ? Uri.joinPath(workspaceFolder.uri, 'presentation.md') : undefined
 
   const targetUri = await window.showSaveDialog({
     defaultUri,

--- a/src/commands/newPresentation.ts
+++ b/src/commands/newPresentation.ts
@@ -1,0 +1,104 @@
+import { commands, Uri, window, workspace } from 'vscode'
+import path from 'path'
+
+export const NEW_PRESENTATION = 'vscode-revealjs.newPresentation'
+export type NEW_PRESENTATION = typeof NEW_PRESENTATION
+
+export type SupportFile = {
+  filename: string
+  content: string
+}
+
+type PresentationTemplate = {
+  label: string
+  description: string
+  markdown: (title: string, localCssFile?: string) => string
+  getSupportFiles?: (presentationFilepath: string) => SupportFile[]
+}
+
+const templates: PresentationTemplate[] = [
+  {
+    label: 'Minimal',
+    description: 'Simple slide deck with front matter and two slides',
+    markdown: (title: string) => `---\ntitle: "${title}"\ntheme: "black"\ntransition: "slide"\n---\n\n# ${title}\n\nWelcome to your new Reveal.js presentation.\n\n---\n\n## Agenda\n\n- Introduce the topic\n- Walk through key points\n- Wrap up with questions\n`,
+  },
+  {
+    label: 'Code-heavy',
+    description: 'Starter deck focused on code snippets',
+    markdown: (title: string) => `---\ntitle: "${title}"\ntheme: "night"\nhighlightTheme: "monokai"\ntransition: "fade"\n---\n\n# ${title}\n\nPractical examples and implementation details.\n\n---\n\n## Example\n\n\`\`\`ts\nconst greet = (name: string) => "Hello \${name}"\n\nconsole.log(greet('Reveal'))\n\`\`\`\n\n---\n\n## Takeaways\n\n- Keep examples small\n- Explain the why\n- Leave time for Q&A\n`,
+  },
+  {
+    label: 'Speaker notes',
+    description: 'Includes presenter notes in each section',
+    markdown: (title: string) => `---\ntitle: "${title}"\ntheme: "league"\nshowNotes: true\n---\n\n# ${title}\n\nPresenter-ready outline.\n\nNote:\nStart with a short story to set context.\n\n---\n\n## Key point\n\nUse this slide for your main argument.\n\nNote:\nPause here and check audience understanding.\n`,
+  },
+  {
+    label: 'Custom theme',
+    description: 'Deck with local CSS override file',
+    markdown: (title: string, localCssFile?: string) => `---\ntitle: "${title}"\ntheme: "white"\ncss:\n  - "${localCssFile}"\n---\n\n# ${title}\n\nA presentation with local styling.\n\n---\n\n## Styled content\n\nThis template uses a local CSS file for customization.\n`,
+    getSupportFiles: () => [
+      {
+        filename: 'presentation.css',
+        content: `:root {\n  --r-heading-color: #005fb8;\n}\n\n.reveal .slides section {\n  text-align: left;\n}\n`,
+      },
+    ],
+  },
+]
+
+export const getTemplateChoices = () => templates.map((t) => ({ label: t.label, description: t.description }))
+
+export const scaffoldTemplate = (templateLabel: string, targetUri: Uri) => {
+  const selectedTemplate = templates.find((t) => t.label === templateLabel)
+  if (!selectedTemplate) {
+    return null
+  }
+
+  const title = path.basename(targetUri.fsPath, path.extname(targetUri.fsPath)) || 'New Presentation'
+  const supportFiles = selectedTemplate.getSupportFiles?.(targetUri.fsPath) ?? []
+  const cssRef = supportFiles.length > 0 ? supportFiles[0].filename : undefined
+
+  return {
+    content: selectedTemplate.markdown(title, cssRef),
+    supportFiles,
+  }
+}
+
+export const createPresentationFromTemplate = async () => {
+  const template = await window.showQuickPick(getTemplateChoices(), {
+    placeHolder: 'Choose a starter template for your presentation',
+  })
+
+  if (!template) {
+    return
+  }
+
+  const workspaceFolder = workspace.workspaceFolders?.[0]
+  const defaultUri = workspaceFolder ? Uri.file(path.join(workspaceFolder.uri.fsPath, 'presentation.md')) : undefined
+
+  const targetUri = await window.showSaveDialog({
+    defaultUri,
+    saveLabel: 'Create Presentation',
+    filters: {
+      Markdown: ['md'],
+    },
+  })
+
+  if (!targetUri) {
+    return
+  }
+
+  const scaffold = scaffoldTemplate(template.label, targetUri)
+  if (!scaffold) {
+    return
+  }
+
+  for (const supportFile of scaffold.supportFiles) {
+    const supportPath = path.join(path.dirname(targetUri.fsPath), supportFile.filename)
+    await workspace.fs.writeFile(Uri.file(supportPath), new TextEncoder().encode(supportFile.content))
+  }
+
+  await workspace.fs.writeFile(targetUri, new TextEncoder().encode(scaffold.content))
+
+  await commands.executeCommand('vscode.open', targetUri)
+  window.showInformationMessage(`Created presentation: ${path.basename(targetUri.fsPath)}`)
+}

--- a/src/commands/newPresentation.ts
+++ b/src/commands/newPresentation.ts
@@ -93,8 +93,8 @@ export const createPresentationFromTemplate = async () => {
   }
 
   for (const supportFile of scaffold.supportFiles) {
-    const supportPath = path.join(path.dirname(targetUri.fsPath), supportFile.filename)
-    await workspace.fs.writeFile(Uri.file(supportPath), new TextEncoder().encode(supportFile.content))
+    const supportUri = Uri.joinPath(targetUri, '..', supportFile.filename)
+    await workspace.fs.writeFile(supportUri, new TextEncoder().encode(supportFile.content))
   }
 
   await workspace.fs.writeFile(targetUri, new TextEncoder().encode(scaffold.content))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { GO_TO_SLIDE } from './commands/goToSlide'
 import { SHOW_REVEALJS } from './commands/showRevealJS'
 import { SHOW_REVEALJS_IN_BROWSER, showRevealJSInBrowser } from './commands/showRevealJSInBrowser'
 import { showSample, SHOW_SAMPLE } from './commands/showSample'
+import { createPresentationFromTemplate, NEW_PRESENTATION } from './commands/newPresentation'
 import { STOP_REVEALJS_SERVER } from './commands/stopRevealJSServer'
 import languageCompletion from './CompletionItemProvider'
 import MainController from './MainController'
@@ -50,6 +51,7 @@ export function activate(context: ExtensionContext) {
     registerCmd(SHOW_REVEALJS_IN_BROWSER, showRevealJSInBrowser(() =>main.currentContext?.startServer() )),
     registerCmd(STOP_REVEALJS_SERVER, () => main.stopServer()),
     registerCmd(SHOW_SAMPLE, () => showSample(context.extensionPath)),
+    registerCmd(NEW_PRESENTATION, createPresentationFromTemplate),
     registerCmd(GO_TO_SLIDE, (arg) => main.goToSlide(arg.horizontal, arg.vertical)),
     registerCmd(EXPORT_PDF,exportPDF(() => main.currentContext?.startServer())),
     registerCmd(EXPORT_HTML,exportHTML(logger, main.exportAsync, main.shouldOpenFilemanagerAfterHTMLExport)),

--- a/src/test/UnitTests/newPresentation.jest.ts
+++ b/src/test/UnitTests/newPresentation.jest.ts
@@ -1,0 +1,21 @@
+import { Uri } from 'vscode'
+import { getTemplateChoices, scaffoldTemplate } from '../../commands/newPresentation'
+
+test('new presentation templates include required starter options', () => {
+  const labels = getTemplateChoices().map((choice) => choice.label)
+
+  expect(labels).toContain('Minimal')
+  expect(labels).toContain('Code-heavy')
+  expect(labels).toContain('Speaker notes')
+})
+
+test('custom theme scaffold creates a markdown css reference and support file', () => {
+  const targetUri = { fsPath: '/tmp/demo.md' } as Uri
+  const scaffold = scaffoldTemplate('Custom theme', targetUri)
+
+  expect(scaffold).toBeTruthy()
+  expect(scaffold?.content).toContain('css:')
+  expect(scaffold?.content).toContain('presentation.css')
+  expect(scaffold?.supportFiles).toHaveLength(1)
+  expect(scaffold?.supportFiles[0].filename).toBe('presentation.css')
+})


### PR DESCRIPTION
### Motivation
- Provide a quick way to scaffold new Reveal.js presentations from starter templates to address usability issue #1408.
- Keep template assets local to the presentation by creating support files only when required by the chosen template.

### Description
- Added a new command and handler in `src/commands/newPresentation.ts` that implements templates (`Minimal`, `Code-heavy`, `Speaker notes`, `Custom theme`) and exposes `createPresentationFromTemplate`, `scaffoldTemplate`, and `getTemplateChoices`.
- Wired the command into activation by registering `NEW_PRESENTATION` in `src/extension.ts` and contributing `vscode-revealjs.newPresentation` in `package.json` activation events and command contributions.
- Implemented support-file generation for templates that need it (for example `presentation.css` for `Custom theme`) and writing the scaffolded markdown to disk via the VS Code `workspace.fs` API.
- Documented the new feature in `README.md` and added unit tests in `src/test/UnitTests/newPresentation.jest.ts` covering template availability and scaffold behaviour.

### Testing
- Ran `npm test -- newPresentation.jest.ts` which passed (2 tests: template list and Custom theme scaffold).
- Ran `npm run test-compile` (`tsc -p ./`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9cd01808832c8285202bc9217cab)