### PR TITLE
Add pull_request CI trigger and VS Code extension packaging smoke test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: continuous integration Build Matrix
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
@@ -34,3 +36,6 @@ jobs:
 
       - name: Build project
         run: npm run vscode:prepublish
+      - name: Package extension smoke test
+        run: npx --yes @vscode/vsce package --no-dependencies
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
 
@@ -36,6 +36,9 @@ jobs:
 
       - name: Build project
         run: npm run vscode:prepublish
+      - name: Install vsce
+        run: npm install -g vsce
+
       - name: Package extension smoke test
-        run: npx --yes @vscode/vsce package --no-dependencies
+        run: vsce package
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,11 +36,11 @@ jobs:
       version: ${{ steps.setup-tag.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
 


### PR DESCRIPTION
### Motivation
- Ensure pull requests run the same CI checks as pushes so PRs are validated before merge. 
- Detect broken VS Code extension packaging early by adding an explicit packaging smoke test to CI.

### Description
- Update `.github/workflows/build.yml` to trigger on both `push` and `pull_request` instead of push-only. 
- Add a new step `Package extension smoke test` that runs `npx --yes @vscode/vsce package --no-dependencies` after the build step. 
- Preserve the existing matrix, `npm run coverage`, SonarCloud scan, and `npm run vscode:prepublish` build steps.

### Testing
- No automated test runs were executed locally; the change enables the CI job to run `npm run coverage` and the new packaging smoke test on both pushes and pull requests once the workflow runs in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab4646ba8832cbd28cf2d15af079a)