### PR TITLE
fix: align VS Code engine with @types/vscode requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "vscode": "^1.68.0"
+        "vscode": "^1.105.0"
       }
     },
     "node_modules/@alex_neo/jest-expect-message": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/evilz/vscode-reveal"
   },
   "engines": {
-    "vscode": "^1.68.0"
+    "vscode": "^1.105.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
### Motivation
- The smoke test reported `@types/vscode@^1.105.0` is newer than the extension `engines.vscode` (`^1.68.0`), causing a compatibility warning that must be resolved.

### Description
- Bumped the extension engine constraint in `package.json` from `"vscode": "^1.68.0"` to `"vscode": "^1.105.0"` to match `@types/vscode`.
- Synchronized the same `engines.vscode` value in the `package-lock.json` root package metadata to keep the lockfile aligned.
- Only the `engines.vscode` entries in `package.json` and `package-lock.json` were changed.

### Testing
- Ran `npm run test-compile` (which executes `tsc -p ./`) and it completed successfully.
- Attempted `npm install --save-dev @types/vscode@1.68.0`, but the install failed with a `403 Forbidden` from the registry due to environment/security policy, which did not block the compilation check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5a6fdc70832caa65144e06edc7c4)