### PR TITLE
Refresh preview when referenced local assets change

### DIFF
--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -69,7 +69,6 @@ export default class MainController {
   private OnEditorEvent(editor: TextEditor, newPosition: Position) {
     if (isMarkdownFile(editor.document)) {
       this.currentContext = this.revealContexts.getOrAdd(editor)
-      this.syncAssetWatchers()
       this.updatePosition(newPosition)
       this.refresh()
     }

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -18,16 +18,20 @@ import {
   commands,
   ConfigurationChangeEvent,
   ExtensionContext,
+  FileSystemWatcher,
   Position,
+  RelativePattern,
   TextDocument,
   TextDocumentChangeEvent,
   TextEditor,
   TextEditorSelectionChangeEvent,
+  workspace,
   ViewColumn,
   window,
 } from 'vscode'
 
 import * as jetpack from 'fs-jetpack'
+import path from 'path'
 
 import { SHOW_REVEALJS } from './commands/showRevealJS'
 import Logger from './Logger'
@@ -47,6 +51,7 @@ export default class MainController {
   private webViewPane?: WebViewPane
   public currentContext?: RevealContext
   private readonly revealContexts: RevealContexts
+  private readonly assetWatchers = new Map<string, FileSystemWatcher>()
 
   get baseUri() {
     return this.currentContext?.baseUri
@@ -64,6 +69,7 @@ export default class MainController {
   private OnEditorEvent(editor: TextEditor, newPosition: Position) {
     if (isMarkdownFile(editor.document)) {
       this.currentContext = this.revealContexts.getOrAdd(editor)
+      this.syncAssetWatchers()
       this.updatePosition(newPosition)
       this.refresh()
     }
@@ -97,6 +103,7 @@ export default class MainController {
     if (this.currentContext?.is(document)) {
       this.currentContext = undefined
       this.revealContexts.remove(document.uri)
+      this.syncAssetWatchers()
       this.logger.debug(`onDidCloseTextDocument ${document.uri}`)
     }
   }
@@ -180,6 +187,7 @@ export default class MainController {
 
       this.logger.info(`REFRESH START!`)
       const { slides } = this.currentContext.refresh()
+      this.syncAssetWatchers()
 
       this.refreshWebViewPane()
       this.slidesExplorer.update()
@@ -187,6 +195,39 @@ export default class MainController {
       this.textDecorator.update(this.currentContext.editor)
       this.logger.info(`REFRESH DONE!`)
     }, wait)
+  }
+
+  private syncAssetWatchers() {
+    const watchedPaths = new Set(this.currentContext?.getReferencedAssetPaths() ?? [])
+
+    for (const [assetPath, watcher] of this.assetWatchers.entries()) {
+      if (!watchedPaths.has(assetPath)) {
+        watcher.dispose()
+        this.assetWatchers.delete(assetPath)
+      }
+    }
+
+    for (const assetPath of watchedPaths) {
+      if (this.assetWatchers.has(assetPath)) {
+        continue
+      }
+
+      const watcher = workspace.createFileSystemWatcher(
+        new RelativePattern(path.dirname(assetPath), path.basename(assetPath)),
+        false,
+        false,
+        false
+      )
+      const onAssetChanged = () => {
+        this.logger.debug(`onDidChangeAsset: ${assetPath}`)
+        this.refresh(50)
+      }
+
+      watcher.onDidChange(onAssetChanged)
+      watcher.onDidCreate(onAssetChanged)
+      watcher.onDidDelete(onAssetChanged)
+      this.assetWatchers.set(assetPath, watcher)
+    }
   }
 
   updatePosition(cursorPosition: Position) {

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -64,6 +64,40 @@ export class RevealContext extends Disposable {
       : path.join(this.dirname, this.configuration.exportHTMLPath)
   }
 
+  private resolveLocalAssetPath(assetPath: string | null | undefined, appendCssIfMissing = false): string | null {
+    if (!assetPath) return null
+
+    const trimmed = assetPath.trim()
+    if (!trimmed) return null
+    if (/^(https?:)?\/\//i.test(trimmed) || /^data:/i.test(trimmed)) return null
+
+    const [cleanedPath] = trimmed.split(/[?#]/)
+    const resolvedPath = path.isAbsolute(cleanedPath) ? cleanedPath : path.resolve(this.dirname, cleanedPath)
+    if (appendCssIfMissing && !path.extname(resolvedPath)) {
+      return `${resolvedPath}.css`
+    }
+    return resolvedPath
+  }
+
+  public getReferencedAssetPaths(): string[] {
+    const paths = new Set<string>()
+    paths.add(path.join(this.dirname, 'init.js'))
+
+    const customThemePath = this.resolveLocalAssetPath(this.configuration.customTheme, true)
+    if (customThemePath) {
+      paths.add(customThemePath)
+    }
+
+    for (const cssAssetPath of this.configuration.css) {
+      const resolvedPath = this.resolveLocalAssetPath(cssAssetPath)
+      if (resolvedPath) {
+        paths.add(resolvedPath)
+      }
+    }
+
+    return [...paths]
+  }
+
   public refresh() {
     const { frontmatter, slides } = slideParser.parse(this.getText(), this.configuration)
     this.slides = slides


### PR DESCRIPTION
### Motivation
- The preview should update when local assets referenced by a Markdown context (like `init.js`, a `customTheme`, or entries in `css[]`) are created/modified/deleted so the rendered presentation stays in sync with those files.
- Current behavior only refreshed on Markdown edits or saves, which misses changes to external assets that affect the webview output (issue #1397). 

### Description
- Added asset discovery to `RevealContext` via `resolveLocalAssetPath` and `getReferencedAssetPaths` to return concrete local file paths for `init.js`, `customTheme` (automatically appends `.css` when needed), and items in the `css` array while ignoring remote/data URLs. 
- Added an `assetWatchers` map and a `syncAssetWatchers` method in `MainController` that creates `workspace.createFileSystemWatcher` watchers (using `RelativePattern`) for referenced assets and disposes watchers that are no longer needed. 
- Wire-up points: `syncAssetWatchers` is called when the active editor/context is set (`OnEditorEvent`), after `refresh()` runs to re-sync watchers, and when a document is closed so watcher lifecycle follows the active context.
- When a watched asset is created/changed/deleted the watcher triggers a fast debounced `refresh(50)` so the preview updates quickly.

### Testing
- Ran unit tests: `npm run -s test -- RevealServer.jest.ts MainController.jest.ts` and both suites passed (all tests and snapshots OK). 
- Type-check/build validation: `npm run -s test-compile` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db77222c98832c804b4b6c281ac344)