### PR TITLE
Inject bridge into WebView, fetch preview HTML, and handle slide change messages

### DIFF
--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -249,6 +249,15 @@ export default class MainController {
     } else {
       const webviewPanel = window.createWebviewPanel('RevealJS', 'Reveal JS presentation', ViewColumn.Beside, { enableScripts: true })
       this.webViewPane = new WebViewPane(webviewPanel)
+      this.webViewPane.onDidReceiveMessage((message) => {
+        const msg = message as any
+        if (!msg || typeof msg !== 'object' || msg.command !== 'slideChanged') return
+
+        const horizontal = Number(msg.horizontal)
+        const vertical = Number(msg.vertical)
+        if (!Number.isFinite(horizontal) || !Number.isFinite(vertical)) return
+        this.goToSlide(horizontal, vertical)
+      })
       this.webViewPane.onDidDispose(() => {
         this.logInfo('WebView', 'disposed')
         this.webViewPane = undefined
@@ -262,7 +271,7 @@ export default class MainController {
     if (this.webViewPane && this.currentContext) {
       this.startServer()
       this.webViewPane.title = this.currentContext.configuration.title
-      this.webViewPane.update(this.currentContext.uriWithPosition)
+      void this.webViewPane.update(this.currentContext.uriWithPosition)
     }
   }
 

--- a/src/WebViewPane.ts
+++ b/src/WebViewPane.ts
@@ -3,10 +3,14 @@ import { Disposable } from "./dispose";
 
 export default class WebviewPane
     extends Disposable {
+    #isDisposed = false
 
     constructor(private webviewPanel:WebviewPanel) {
         super()
         this.webviewPanel.onDidDispose(() => { this.dispose() })
+        this.webviewPanel.webview.onDidReceiveMessage((message: unknown) => {
+          this.#onDidReceiveMessage.fire(message)
+        })
     }
 
     readonly #onDidDispose = this._register(new EventEmitter<void>());
@@ -21,56 +25,94 @@ export default class WebviewPane
 	 */
 	public readonly onDidUpdate = this.#onDidUpdate.event;
 
+    readonly #onDidReceiveMessage = this._register(new EventEmitter<unknown>());
+	/**
+	 * Fired when a message is received from the webview.
+	 */
+	public readonly onDidReceiveMessage = this.#onDidReceiveMessage.event;
+
 
     /** Set title of web pane */
     public set title(title:string) {
         this.webviewPanel.title = title;
     }
     
-    public update(url:string) {
-        this.webviewPanel.webview.html = `
-        <!doctype html>
-        <html lang="en">
-        <head>
-              <style>html, body, iframe { height: 100% }</style>
-        </head>
-        <body>
-              <iframe id="revealIframe" src="${url}" frameBorder="0" style="width: 100%; height: 100%" />
-        </body>
-        </html>
-              `;
+    public async update(url:string) {
+        try {
+          const parsedUrl = new URL(url)
+          const slideHash = parsedUrl.hash || '#/'
+          parsedUrl.hash = ''
 
+          const response = await fetch(parsedUrl.toString())
+          if (!response.ok || this.#isDisposed) return
 
-        this.#onDidUpdate.fire()
+          const html = await response.text()
+          if (this.#isDisposed) return
+
+          const htmlWithBase = this.injectBaseHref(html, parsedUrl.toString())
+          this.webviewPanel.webview.html = this.injectBridgeScript(htmlWithBase, slideHash)
+          this.#onDidUpdate.fire()
+        } catch (_error) {
+          // Ignore transient preview loading failures (e.g. server restarts).
+        }
     }
- // Code without iframe
-      // const uri = this.getUri(false)
-      // if (uri !== null) {
-      //   http.get(uri, (res) => {
-      //     res.setEncoding('utf8')
-      //     let body = ''
-      //     res.on('data', (data) => {
-      //       body += data
-      //     })
-      //     res.on('end', () => {
-      //       if (this.webviewPanel) {
-      //         this.webviewPanel.webview.html = body
-      //       }
-      //     })
-      //   })
-      // }
 
-      // Handle messages from the webview
-      // this.webviewPanel.webview.onDidReceiveMessage((message) => {
-      //   switch (message.command) {
-      //     case 'getSlides':
-      //       window.showInformationMessage(message.text)
-      //       window.showInformationMessage(message.slides.length.toString())
-      //       return
-      //   }
-      // }, null)
+    private injectBaseHref(html: string, baseUrl: string) {
+      const baseTag = `<base href="${baseUrl}">`
+      if (html.includes('<head>')) {
+        return html.replace('<head>', `<head>\n${baseTag}`)
+      }
+      return `${baseTag}${html}`
+    }
+
+    private injectBridgeScript(html: string, slideHash: string) {
+      const script = `
+      <script>
+        (function () {
+          const vscode = acquireVsCodeApi();
+          const initialHash = ${JSON.stringify(slideHash)};
+
+          const postCurrentSlide = () => {
+            const match = window.location.hash.match(/#\\/(\\d+)\\/(\\d+)/);
+            if (!match) return;
+            vscode.postMessage({
+              command: 'slideChanged',
+              horizontal: Number(match[1]),
+              vertical: Number(match[2]),
+              hash: window.location.hash,
+            });
+          };
+
+          window.addEventListener('hashchange', postCurrentSlide);
+
+          if (window.Reveal && typeof window.Reveal.on === 'function') {
+            window.Reveal.on('slidechanged', postCurrentSlide);
+          }
+
+          window.addEventListener('message', (event) => {
+            const message = event.data;
+            if (message && message.command === 'setSlide' && typeof message.hash === 'string') {
+              window.location.hash = message.hash;
+            }
+          });
+
+          if (initialHash) {
+            window.location.hash = initialHash;
+          }
+
+          setTimeout(postCurrentSlide, 0);
+        }());
+      </script>
+      `
+
+      if (html.includes('</body>')) {
+        return html.replace('</body>', `${script}\n</body>`)
+      }
+      return `${html}\n${script}`
+    }
   
     public dispose() {
+        this.#isDisposed = true
         this.#onDidDispose.fire();
         super.dispose();
     }

--- a/src/test/UnitTests/WebviewPane.jest.ts
+++ b/src/test/UnitTests/WebviewPane.jest.ts
@@ -4,7 +4,8 @@ import {Event, WebviewPanel} from "vscode"
 test('Set title of webviewpane', () => {
 
     const onDidDispose = jest.fn( ) as Event<void>
-    const webviewPanel = {title: "test" , onDidDispose: onDidDispose  }  as WebviewPanel 
+    const onDidReceiveMessage = jest.fn() as Event<unknown>
+    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, webview: { html: "", onDidReceiveMessage } }  as unknown as WebviewPanel 
     const pane = new WebviewPane( webviewPanel )
     pane.title = "new title"
   
@@ -15,8 +16,9 @@ test('Set title of webviewpane', () => {
   test('Dispose should trigger onDidDispose', () => {
 
     const onDidDispose = jest.fn( ) as Event<void>
+    const onDidReceiveMessage = jest.fn() as Event<unknown>
     const dispose = jest.fn() as (()=>unknown)
-    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, dispose : dispose }  as WebviewPanel 
+    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, dispose : dispose, webview: { html: "", onDidReceiveMessage } }  as unknown as WebviewPanel 
     const pane = new WebviewPane( webviewPanel )
   
     const onDidDisposeFn = jest.fn()
@@ -29,16 +31,33 @@ test('Set title of webviewpane', () => {
   })
 
 
-  test('Update should trigger onDidUpdate', () => {
+  test('Update should trigger onDidUpdate', async () => {
 
     const onDidDispose = jest.fn( ) as Event<void>
+    const onDidReceiveMessage = jest.fn() as Event<unknown>
     const dispose = jest.fn() as (()=> unknown)
-    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, dispose : dispose, webview: {html:""} }  as WebviewPanel 
+    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, dispose : dispose, webview: {html:"", onDidReceiveMessage} }  as unknown as WebviewPanel 
     const pane = new WebviewPane( webviewPanel )
+    ;(global as unknown as { fetch: jest.Mock }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue('<html><head></head><body>hello</body></html>')
+    })
   
     const onDidUpdate = jest.fn()
     pane.onDidUpdate(onDidUpdate)
-    pane.update("some uri")
+    await pane.update("http://localhost:1234/#/1/2")
     
     expect(onDidUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  test('Update should handle fetch errors', async () => {
+    const onDidDispose = jest.fn( ) as Event<void>
+    const onDidReceiveMessage = jest.fn() as Event<unknown>
+    const dispose = jest.fn() as (()=> unknown)
+    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, dispose : dispose, webview: {html:"", onDidReceiveMessage} }  as unknown as WebviewPanel 
+    const pane = new WebviewPane( webviewPanel )
+    ;(global as unknown as { fetch: jest.Mock }).fetch = jest.fn().mockRejectedValue(new Error('network'))
+  
+    await expect(pane.update("http://localhost:1234/#/1/2")).resolves.toBeUndefined()
+    expect(webviewPanel.webview.html).toBe("")
   })


### PR DESCRIPTION
### Motivation

- Replace fragile iframe approach with an in-pane HTML preview that can communicate slide changes back to the extension.
- Ensure the webview can resolve relative assets by setting a proper base URL when loading the preview HTML.
- Add robust handling for transient load errors and support bi-directional messaging for slide navigation.

### Description

- Updated `WebviewPane` to fetch the preview HTML via `fetch` in `update`, inject a `<base>` tag and a bridge script, and set the panel HTML instead of using an iframe by implementing `update(url: string)` as `async`.
- Added `injectBaseHref` to add a `<base href=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db804c34f0832c85c864a337b4a18a)