### PR TITLE
Use VS Code native APIs for external open actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ To display presentation in the browser you can:
 - call command `Revealjs: Open presentation in a browser`
 
 
-This will try to use Chrome that is the best browser to use for reveal.js presentation, if it can't find it, your default browser will be used.
+This uses VS Code's native external URL API by default (same behavior as opening a URL from VS Code).
+
+If `revealjs.browserPath` is set, the extension uses that executable path to launch the presentation instead of the VS Code default external opener.
 
 
 ## <a id="pdf"></a> Print to PDF
@@ -206,7 +208,9 @@ To export your presentation to pdf you can:
 - call the command `Revealjs: Export in PDF`
 
 
-This will try to launch Chrome or your default browser and launch printing.
+This opens the print URL using the same browser resolution rules as above:
+- if `revealjs.browserPath` is set and valid, that executable is used
+- otherwise VS Code's native external URL API is used
 Be sure to set print setting correctly:
 - No margin
 - print background
@@ -219,7 +223,11 @@ To export your presentation to a static website you can:
 - call the command `Revealjs: Export in HTML`
 
 
-This will try to launch Chrome in headless or your default browser it takes about 10sec and then open the export folder.
+The export runs in the extension host and then opens the export folder using VS Code native APIs.
+
+Folder-open fallback behavior:
+- first try `revealFileInOS` (native reveal in file manager)
+- if unavailable, fallback to `vscode.env.openExternal` with a `file://` URI
 
 ## <a id="plugins"></a> Plugins
 

--- a/src/commands/exportHTML.ts
+++ b/src/commands/exportHTML.ts
@@ -1,7 +1,7 @@
-import open from 'open'
-import  Logger from '../Logger'
+import Logger from '../Logger'
 
 import { window, ProgressLocation } from 'vscode'
+import { openFolder } from './openExternal'
 
 export const EXPORT_HTML = 'vscode-revealjs.exportHTML'
 export type EXPORT_HTML = typeof EXPORT_HTML
@@ -22,7 +22,7 @@ export const exportHTML = (logger: Logger, startExport: () => Promise<string>, d
       if (doOpenAfterExport()) {
         progress.report({ message: 'Opening out folder !' })
         await timeout(1500)
-        open(path)
+        await openFolder(path)
         logger.debug('Open folder: ' + path)
       }
     }

--- a/src/commands/exportPDF.ts
+++ b/src/commands/exportPDF.ts
@@ -1,13 +1,13 @@
-import open from 'open'
+import { openInBrowser } from './openExternal'
 
 export const EXPORT_PDF = 'vscode-revealjs.exportPDF'
 export type EXPORT_PDF = typeof EXPORT_PDF
 
-export const exportPDF = (getUri: () => string | undefined) => () => {
+export const exportPDF = (getUri: () => string | undefined, getBrowserPath?: () => string | null | undefined) => async () => {
   const uri = getUri()
   if (uri === undefined) {
     return
   }
   const url = uri + '?print-pdf-now'
-  return open(url)
+  return openInBrowser(url, getBrowserPath?.())
 }

--- a/src/commands/openExternal.ts
+++ b/src/commands/openExternal.ts
@@ -1,0 +1,31 @@
+import open from 'open'
+import { commands, env, Uri } from 'vscode'
+
+const trimOrNull = (value: string | null | undefined): string | null => {
+  if (!value) return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export const openInBrowser = async (targetUrl: string, browserPath?: string | null) => {
+  const customBrowserPath = trimOrNull(browserPath)
+  if (customBrowserPath) {
+    return open(targetUrl, {
+      app: {
+        name: customBrowserPath,
+      },
+    })
+  }
+  return env.openExternal(Uri.parse(targetUrl))
+}
+
+export const openFolder = async (folderPath: string) => {
+  const folderUri = Uri.file(folderPath)
+
+  try {
+    await commands.executeCommand('revealFileInOS', folderUri)
+    return
+  } catch {
+    return env.openExternal(folderUri)
+  }
+}

--- a/src/commands/showRevealJSInBrowser.ts
+++ b/src/commands/showRevealJSInBrowser.ts
@@ -1,12 +1,13 @@
-import open from 'open'
+import { openInBrowser } from './openExternal'
 
 export const SHOW_REVEALJS_IN_BROWSER = 'vscode-revealjs.showRevealJSInBrowser'
 export type SHOW_REVEALJS_IN_BROWSER = typeof SHOW_REVEALJS_IN_BROWSER
 
-export const showRevealJSInBrowser = (getUri: () => string | undefined) => () => {
+export const showRevealJSInBrowser = (getUri: () => string | undefined, getBrowserPath?: () => string | null | undefined) => async () => {
   const uri = getUri()
   if (uri === undefined) {
     return
   }
-  return open(uri)
+
+  return openInBrowser(uri, getBrowserPath?.())
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,12 +48,12 @@ export function activate(context: ExtensionContext) {
 
   context.subscriptions.push(
     registerCmd(SHOW_REVEALJS, () => main.showWebViewPane()  ),
-    registerCmd(SHOW_REVEALJS_IN_BROWSER, showRevealJSInBrowser(() =>main.currentContext?.startServer() )),
+    registerCmd(SHOW_REVEALJS_IN_BROWSER, showRevealJSInBrowser(() => main.currentContext?.startServer(), () => main.currentContext?.configuration.browserPath )),
     registerCmd(STOP_REVEALJS_SERVER, () => main.stopServer()),
     registerCmd(SHOW_SAMPLE, () => showSample(context.extensionPath)),
     registerCmd(NEW_PRESENTATION, createPresentationFromTemplate),
     registerCmd(GO_TO_SLIDE, (arg) => main.goToSlide(arg.horizontal, arg.vertical)),
-    registerCmd(EXPORT_PDF,exportPDF(() => main.currentContext?.startServer())),
+    registerCmd(EXPORT_PDF,exportPDF(() => main.currentContext?.startServer(), () => main.currentContext?.configuration.browserPath)),
     registerCmd(EXPORT_HTML,exportHTML(logger, main.exportAsync, main.shouldOpenFilemanagerAfterHTMLExport)),
 
     window.onDidChangeTextEditorSelection((e) => main.onDidChangeTextEditorSelection(e)),

--- a/src/test/UnitTests/openExternal.jest.ts
+++ b/src/test/UnitTests/openExternal.jest.ts
@@ -1,0 +1,68 @@
+const openMock = jest.fn()
+const executeCommandMock = jest.fn()
+const openExternalMock = jest.fn()
+const parseMock = jest.fn((value: string) => ({ kind: 'parse', value }))
+const fileMock = jest.fn((value: string) => ({ kind: 'file', value }))
+
+jest.mock('open', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => openMock(...args),
+}))
+
+jest.mock('vscode', () => ({
+  commands: {
+    executeCommand: (...args: any[]) => executeCommandMock(...args),
+  },
+  env: {
+    openExternal: (...args: any[]) => openExternalMock(...args),
+  },
+  Uri: {
+    parse: (value: string) => parseMock(value),
+    file: (value: string) => fileMock(value),
+  },
+}))
+
+import { openFolder, openInBrowser } from '../../commands/openExternal'
+
+describe('openExternal helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('openInBrowser uses custom browser when browserPath is configured', async () => {
+    await openInBrowser('http://localhost:1948', ' /custom/browser ')
+
+    expect(openMock).toHaveBeenCalledWith('http://localhost:1948', {
+      app: {
+        name: '/custom/browser',
+      },
+    })
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  test('openInBrowser uses vscode env when browserPath is empty', async () => {
+    await openInBrowser('http://localhost:1948', '   ')
+
+    expect(parseMock).toHaveBeenCalledWith('http://localhost:1948')
+    expect(openExternalMock).toHaveBeenCalledWith({ kind: 'parse', value: 'http://localhost:1948' })
+    expect(openMock).not.toHaveBeenCalled()
+  })
+
+  test('openFolder prefers revealFileInOS', async () => {
+    executeCommandMock.mockResolvedValue(undefined)
+
+    await openFolder('/tmp/export')
+
+    expect(fileMock).toHaveBeenCalledWith('/tmp/export')
+    expect(executeCommandMock).toHaveBeenCalledWith('revealFileInOS', { kind: 'file', value: '/tmp/export' })
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  test('openFolder falls back to openExternal when revealFileInOS fails', async () => {
+    executeCommandMock.mockRejectedValue(new Error('unsupported'))
+
+    await openFolder('/tmp/export')
+
+    expect(openExternalMock).toHaveBeenCalledWith({ kind: 'file', value: '/tmp/export' })
+  })
+})


### PR DESCRIPTION
### Motivation
- Replace ad-hoc use of the external `open` package with VS Code-native APIs to improve platform integration and fallbacks.
- Preserve existing `revealjs.browserPath` behavior when a custom browser executable is explicitly configured.
- Ensure exported HTML folder opening and browser/PDF opens behave consistently across platforms and VS Code environments.

### Description
- Added a shared helper module `src/commands/openExternal.ts` that exposes `openInBrowser(targetUrl, browserPath?)` and `openFolder(folderPath)`; `openInBrowser` uses `vscode.env.openExternal` by default and falls back to `open` only when `revealjs.browserPath` is provided, and `openFolder` tries `revealFileInOS` then falls back to `env.openExternal`.
- Updated `src/commands/showRevealJSInBrowser.ts` and `src/commands/exportPDF.ts` to use `openInBrowser` and accept an optional `getBrowserPath` provider.
- Updated `src/commands/exportHTML.ts` to use `openFolder` to open the export output folder.
- Wired command registrations in `src/extension.ts` to pass the active reveal context's `configuration.browserPath` to browser/PDF commands.
- Added unit tests in `src/test/UnitTests/openExternal.jest.ts` to cover custom-browser handling and folder-open fallback behavior.
- Updated `README.md` to document the new native-first behavior and fallback semantics for browser/PDF/folder opening.

### Testing
- Ran `npm test -- openExternal.jest.ts` and the new test suite passed (4 tests).
- Ran `npm run test-compile` (TypeScript compile via `tsc`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9b746294832caf203c47802acb2f)