### PR TITLE
Add presenter view command for speaker notes workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ This uses VS Code's native external URL API by default (same behavior as opening
 
 If `revealjs.browserPath` is set, the extension uses that executable path to launch the presentation instead of the VS Code default external opener.
 
+## Presenter view / speaker notes
+
+To open a dedicated presenter workflow (speaker notes + current/upcoming slide):
+- call command `Revealjs: Open presenter view in browser`
+- or use `Revealjs: Open presentation in a browser`, then press `S`
+
+How it works with the main deck preview:
+- presenter view opens a browser tab for the current deck and automatically launches Reveal.js speaker view in a second popup window
+- navigation stays synchronized between the deck tab and the speaker window
+- speaker notes authored in markdown (`note:` / `<aside class="notes">`) are shown in the presenter window
+
+Supported execution modes:
+- ✅ external browser mode (default browser or `revealjs.browserPath`): fully supported
+- ⚠️ VS Code webview side preview: does not provide a first-class presenter popup workflow
+
 
 ## <a id="pdf"></a> Print to PDF
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "onCommand:vscode-revealjs.showSample",
     "onCommand:vscode-revealjs.showRevealJS",
     "onCommand:vscode-revealjs.showRevealJSInBrowser",
+    "onCommand:vscode-revealjs.showRevealJSPresenterView",
     "onCommand:vscode-revealjs.newPresentation"
   ],
   "main": "./dist/extension.js",
@@ -56,6 +57,14 @@
       {
         "command": "vscode-revealjs.showRevealJSInBrowser",
         "title": "Revealjs: Open presentation in browser",
+        "icon": {
+          "light": "resources/light/browser.svg",
+          "dark": "resources/dark/browser.svg"
+        }
+      },
+      {
+        "command": "vscode-revealjs.showRevealJSPresenterView",
+        "title": "Revealjs: Open presenter view in browser",
         "icon": {
           "light": "resources/light/browser.svg",
           "dark": "resources/dark/browser.svg"
@@ -542,6 +551,11 @@
           "group": "navigation"
         },
         {
+          "command": "vscode-revealjs.showRevealJSPresenterView",
+          "when": "view == slidesExplorer",
+          "group": "navigation"
+        },
+        {
           "command": "vscode-revealjs.showRevealJS",
           "when": "view == slidesExplorer",
           "group": "navigation"
@@ -567,6 +581,11 @@
           "when": "resourceLangId == markdown",
           "command": "vscode-revealjs.showRevealJSInBrowser",
           "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == markdown",
+          "command": "vscode-revealjs.showRevealJSPresenterView",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
@@ -584,6 +603,11 @@
         {
           "when": "resourceLangId == markdown",
           "command": "vscode-revealjs.showRevealJSInBrowser",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == markdown",
+          "command": "vscode-revealjs.showRevealJSPresenterView",
           "group": "navigation"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
         "command": "vscode-revealjs.showRevealJSPresenterView",
         "title": "Revealjs: Open presenter view in browser",
         "icon": {
-          "light": "resources/light/browser.svg",
-          "dark": "resources/dark/browser.svg"
+          "light": "resources/light/chat.svg",
+          "dark": "resources/dark/chat.svg"
         }
       },
       {

--- a/resources/dark/chat.svg
+++ b/resources/dark/chat.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" xml:space="preserve">
+  <style type="text/css">.st0{fill:#c5c5c5}</style>
+  <path class="st0" d="M2 2h12v8H6.7L3 13.4V10H2V2zm1.8 1.8v4.4h1.1V5.6h7.2v2.6h1.1V3.8H3.8z"/>
+</svg>

--- a/resources/light/chat.svg
+++ b/resources/light/chat.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" xml:space="preserve">
+  <style type="text/css">.st0{fill:#6d6d6d}</style>
+  <path class="st0" d="M2 2h12v8H6.7L3 13.4V10H2V2zm1.8 1.8v4.4h1.1V5.6h7.2v2.6h1.1V3.8H3.8z"/>
+</svg>

--- a/src/commands/showRevealJSInBrowser.ts
+++ b/src/commands/showRevealJSInBrowser.ts
@@ -3,6 +3,15 @@ import { openInBrowser } from './openExternal'
 export const SHOW_REVEALJS_IN_BROWSER = 'vscode-revealjs.showRevealJSInBrowser'
 export type SHOW_REVEALJS_IN_BROWSER = typeof SHOW_REVEALJS_IN_BROWSER
 
+export const SHOW_REVEALJS_PRESENTER_VIEW = 'vscode-revealjs.showRevealJSPresenterView'
+export type SHOW_REVEALJS_PRESENTER_VIEW = typeof SHOW_REVEALJS_PRESENTER_VIEW
+
+export const toPresenterViewUrl = (uri: string) => {
+  const [baseUri, hash = ''] = uri.split('#')
+  const separator = baseUri.includes('?') ? '&' : '?'
+  return `${baseUri}${separator}notes=1${hash ? `#${hash}` : ''}`
+}
+
 export const showRevealJSInBrowser = (getUri: () => string | undefined, getBrowserPath?: () => string | null | undefined) => async () => {
   const uri = getUri()
   if (uri === undefined) {
@@ -10,4 +19,13 @@ export const showRevealJSInBrowser = (getUri: () => string | undefined, getBrows
   }
 
   return openInBrowser(uri, getBrowserPath?.())
+}
+
+export const showRevealJSPresenterView = (getUri: () => string | undefined, getBrowserPath?: () => string | null | undefined) => async () => {
+  const uri = getUri()
+  if (uri === undefined) {
+    return
+  }
+
+  return openInBrowser(toPresenterViewUrl(uri), getBrowserPath?.())
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { EXPORT_HTML, exportHTML } from './commands/exportHTML'
 import { EXPORT_PDF, exportPDF } from './commands/exportPDF'
 import { GO_TO_SLIDE } from './commands/goToSlide'
 import { SHOW_REVEALJS } from './commands/showRevealJS'
-import { SHOW_REVEALJS_IN_BROWSER, showRevealJSInBrowser } from './commands/showRevealJSInBrowser'
+import { SHOW_REVEALJS_IN_BROWSER, SHOW_REVEALJS_PRESENTER_VIEW, showRevealJSInBrowser, showRevealJSPresenterView } from './commands/showRevealJSInBrowser'
 import { showSample, SHOW_SAMPLE } from './commands/showSample'
 import { createPresentationFromTemplate, NEW_PRESENTATION } from './commands/newPresentation'
 import { STOP_REVEALJS_SERVER } from './commands/stopRevealJSServer'
@@ -49,6 +49,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(
     registerCmd(SHOW_REVEALJS, () => main.showWebViewPane()  ),
     registerCmd(SHOW_REVEALJS_IN_BROWSER, showRevealJSInBrowser(() => main.currentContext?.startServer(), () => main.currentContext?.configuration.browserPath )),
+    registerCmd(SHOW_REVEALJS_PRESENTER_VIEW, showRevealJSPresenterView(() => main.currentContext?.startServer(), () => main.currentContext?.configuration.browserPath)),
     registerCmd(STOP_REVEALJS_SERVER, () => main.stopServer()),
     registerCmd(SHOW_SAMPLE, () => showSample(context.extensionPath)),
     registerCmd(NEW_PRESENTATION, createPresentationFromTemplate),

--- a/src/test/UnitTests/showRevealJSInBrowser.jest.ts
+++ b/src/test/UnitTests/showRevealJSInBrowser.jest.ts
@@ -1,0 +1,38 @@
+const openInBrowserMock = jest.fn()
+
+jest.mock('../../commands/openExternal', () => ({
+  openInBrowser: (...args: unknown[]) => openInBrowserMock(...args),
+}))
+
+import {
+  showRevealJSInBrowser,
+  showRevealJSPresenterView,
+  toPresenterViewUrl,
+} from '../../commands/showRevealJSInBrowser'
+
+describe('showRevealJSInBrowser commands', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('toPresenterViewUrl appends notes query before hash', () => {
+    expect(toPresenterViewUrl('http://localhost:1948/#/2/1/123')).toBe('http://localhost:1948/?notes=1#/2/1/123')
+    expect(toPresenterViewUrl('http://localhost:1948/?print-pdf#/0/0')).toBe('http://localhost:1948/?print-pdf&notes=1#/0/0')
+  })
+
+  test('showRevealJSInBrowser opens the raw presentation url', async () => {
+    const run = showRevealJSInBrowser(() => 'http://localhost:1948/#/1/0', () => '/browser')
+
+    await run()
+
+    expect(openInBrowserMock).toHaveBeenCalledWith('http://localhost:1948/#/1/0', '/browser')
+  })
+
+  test('showRevealJSPresenterView opens notes-enabled url', async () => {
+    const run = showRevealJSPresenterView(() => 'http://localhost:1948/#/1/0', () => '/browser')
+
+    await run()
+
+    expect(openInBrowserMock).toHaveBeenCalledWith('http://localhost:1948/?notes=1#/1/0', '/browser')
+  })
+})


### PR DESCRIPTION
### Motivation
- Provide a one-step way to open the Reveal.js presenter workflow (speaker notes + current/upcoming slide) in an external browser so presenters can view notes and timing while the audience sees the deck. 
- Keep existing behavior for opening the deck in a browser while adding an explicit command to launch the speaker/presenter view URL.

### Description
- Added a new command constant and handler `vscode-revealjs.showRevealJSPresenterView` and implemented `showRevealJSPresenterView` in `src/commands/showRevealJSInBrowser.ts` to open a notes-enabled URL. 
- Implemented `toPresenterViewUrl(uri: string)` which appends `notes=1` to the deck URL while preserving existing query parameters and the slide hash. 
- Registered the presenter command in `src/extension.ts` so it starts the reveal server and opens the URL using the same browser resolution logic as the existing browser command. 
- Exposed the command in `package.json` (activation events, commands list and menus for editor/explorer/slide-explorer) and documented the feature in `README.md` under a new "Presenter view / speaker notes" section. 
- Added unit tests `src/test/UnitTests/showRevealJSInBrowser.jest.ts` to validate URL generation and that both browser and presenter commands call the external opener as expected.

### Testing
- Ran the new unit tests with `npm test -- --runInBand src/test/UnitTests/showRevealJSInBrowser.jest.ts` and they passed. 
- Verified TypeScript compilation with `npm run test-compile` (`tsc -p ./`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc5c165e8832ca6eac4243edb40a7)