### PR TITLE
Clean up lint warnings, replace unsafe `any` usages, and tidy tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: 'ts-jest',

--- a/src/Markdown-it.ts
+++ b/src/Markdown-it.ts
@@ -1,5 +1,6 @@
 import attrs from 'markdown-it-attrs'
 import md from 'markdown-it'
+import type { Token } from 'markdown-it'
 import blockEmbed from 'markdown-it-block-embed'
 import multimdTable from 'markdown-it-multimd-table'
 import taskLists from 'markdown-it-task-lists'
@@ -54,23 +55,26 @@ const note = (markdown, config) => {
     }
 
   // tslint:disable-next-line: only-arrow-functions
-  markdown.renderer.rules.paragraph_open = function (tokens: any[], idx, options, env, self) {
-    const inlineToken = tokens[idx + 1] // text
+  markdown.renderer.rules.paragraph_open = function (tokens: Token[], idx, options, env, self) {
+    const currentToken = tokens[idx]!
+    const inlineToken = tokens[idx + 1]! // text
     if (inlineToken.content.startsWith(notesSeparator)) {
-      tokens[idx].tag = 'aside'
-      const classIndex = tokens[idx].attrIndex('class')
+      currentToken.tag = 'aside'
+      const classIndex = currentToken.attrIndex('class')
 
       if (classIndex < 0) {
-        tokens[idx].attrPush(['class', notesClass]) // add new attribute
-      } else {
-        tokens[idx].attrs[classIndex][1] = notesClass // replace value of existing attr
+        currentToken.attrPush(['class', notesClass]) // add new attribute
+      } else if (currentToken.attrs) {
+        currentToken.attrs[classIndex][1] = notesClass // replace value of existing attr
       }
 
       // remote "note:" from content
-      tokens[idx + 1].content = inlineToken.content.replace(notesSeparator, '')
-      tokens[idx + 1].children[0].content = tokens[idx + 1].children[0].content.replace(notesSeparator, '')
+      inlineToken.content = inlineToken.content.replace(notesSeparator, '')
+      if (inlineToken.children && inlineToken.children[0]) {
+        inlineToken.children[0].content = inlineToken.children[0].content.replace(notesSeparator, '')
+      }
 
-      tokens[idx + 2].tag = 'aside'
+      tokens[idx + 2]!.tag = 'aside'
     }
     // pass token to default renderer.
     return defaultRender(tokens, idx, options, env, self)

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -1,7 +1,7 @@
 import { FrontMatterResult } from 'front-matter'
 import path from 'path'
 import { isDeepStrictEqual } from 'util'
-import { EventEmitter, Position, Range, Selection, TextDocument, TextEditor, TextEditorRevealType, Uri } from 'vscode'
+import { EventEmitter, Position, Range, Selection, TextDocument, TextEditor, Uri } from 'vscode'
 import { Configuration, mergeConfig } from './Configuration'
 import { Disposable } from './dispose'
 import { ISlide } from './ISlide'

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -130,6 +130,7 @@ export class RevealServer extends Disposable {
 
     // ERROR HANDLER
     app.use(function (err, req, res, next) {
+      void next
       context.logger.error(err.stack)
       res.status(500).send(err.stack)
     })

--- a/src/SlideParser.ts
+++ b/src/SlideParser.ts
@@ -1,7 +1,7 @@
 import { Configuration } from './Configuration';
 import { ISlide } from './ISlide';
 import { Disposable } from './dispose';
-import frontmatter, { FrontMatterResult } from 'front-matter'
+import frontmatter from 'front-matter'
 
 const trimFirstLastEmptyLine = (s: string): string => {
   let content = s
@@ -42,6 +42,7 @@ export class SlideParser extends Disposable {
   }
 
   public parse(text: string, configuration: Configuration, partial = true) {
+    void partial
     const result = frontmatter<Configuration>(text)
     const slides = this.#parseSlides(result.body, configuration.separator, configuration.verticalSeparator)
     return { frontmatter: result, slides }
@@ -90,4 +91,3 @@ export class SlideParser extends Disposable {
 
 //Singleton
 export default new SlideParser()
-

--- a/src/test/UnitTests/MainController.jest.ts
+++ b/src/test/UnitTests/MainController.jest.ts
@@ -20,22 +20,6 @@ test('CurrentContext should be undefined when no editor is pass', () => {
 });
 
 test('CurrentContext should be undefined when editor is not markdown', () => {
-
-    const editor: TextEditor = {
-        document: { languageId: 'text', fileName: "test.txt" } as TextDocument,
-        selection: new Selection(0, 0, 0, 0),
-        selections: [],
-        visibleRanges: [],
-        options: {},
-        viewColumn: undefined,
-        edit: jest.fn(),
-        insertSnippet: jest.fn(),
-        setDecorations: jest.fn(),
-        revealRange: jest.fn(),
-        show: jest.fn(),
-        hide: jest.fn()
-    }
-
     const main = new MainController(logger, {} as ExtensionContext, [], {} as Configuration, undefined)
     expect(main.currentContext).toBeUndefined()
 });

--- a/src/test/UnitTests/NotTestedYet.jest.ts
+++ b/src/test/UnitTests/NotTestedYet.jest.ts
@@ -1,11 +1,3 @@
-import CompletionItemProvider from "../../CompletionItemProvider" 
-import * as extension from "../../extension"
-import  MainController from "../../MainController"
-import  {SlideTreeProvider} from "../../SlideExplorer"
-import  {StatusBarController} from "../../StatusBarController"
-import  TextDecorator from "../../TextDecorator"
-
-
 test('NOTHING HERE', () => {
 
     expect(true).toBeTruthy()

--- a/src/test/UnitTests/logger.jest.ts
+++ b/src/test/UnitTests/logger.jest.ts
@@ -56,14 +56,3 @@ test('Logger should log when level is info', () => {
 
   expect(output).not.toEqual('')
 });
-
-// test('Logger should Not log when level is debug', () => {
-//   let output = ''
-//   const logger = new Logger((s) => {
-//     output = s
-//   }, LogLevel.Debug)
-
-//   logger.debug('text1')
-
-//   expect(output).not.toEqual('')
-// });

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -61,7 +61,7 @@ export class MarkdownString {
 
 
 export type DocumentSelector = string;
-export type CompletionItemProvider = any
+export type CompletionItemProvider = unknown
 export class Disposable {
   //static from(...disposableLikes: { dispose: () => any }[]): Disposable;
   //constructor(callOnDispose: () => any);
@@ -105,15 +105,17 @@ export class Range {
 
 export interface Event<T> {
 
-  (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]): Disposable;
+  (listener: (e: T) => void, thisArgs?: unknown, disposables?: Disposable[]): Disposable;
 }
 
 export class EventEmitter<T> {
 
-  #listener: (e: T) => any = (x: T) => null
+  #listener: (e: T) => void = (_x: T) => {}
 
   public get event() {
-    return (listener: (ee: T) => any, thisArgs?: any, disposables?: Disposable[]) => {
+    return (listener: (ee: T) => void, thisArgs?: unknown, disposables?: Disposable[]) => {
+      void thisArgs
+      void disposables
       this.#listener = listener
     };
   }
@@ -130,7 +132,7 @@ export class ThemeIcon {
   constructor(public readonly id: string, public readonly color?: ThemeColor) { }
 }
 
-export interface Command { title: string; command: string; tooltip?: string; arguments?: any[]; }
+export interface Command { title: string; command: string; tooltip?: string; arguments?: unknown[]; }
 export enum TreeItemCollapsibleState { None = 0, Collapsed = 1, Expanded = 2 }
 
 export class TreeItem {
@@ -226,7 +228,7 @@ export interface TreeDataProvider<T> {
 
 export type ProviderResult<T> = T | undefined | null | Thenable<T | undefined | null>;
 
-export interface CancellationToken { isCancellationRequested: boolean; onCancellationRequested: Event<any>; }
+export interface CancellationToken { isCancellationRequested: boolean; onCancellationRequested: Event<unknown>; }
 
 export class Selection extends Range {
   //anchor: Position;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,20 +3,8 @@
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
-
-// suite('Extension Test Suite', () => {
-// 	vscode.window.showInformationMessage('Start all tests.');
-
-// 	test('Sample test', () => {
-// 		assert.strictEqual([1, 2, 3].indexOf(5), -1);
-// 		assert.strictEqual([1, 2, 3].indexOf(0), -1);
-// 	});
-// });
-
-
 test('Should start extension @integration', async () => {
-    const testDocument = await vscode.workspace.openTextDocument('../sample.md')
+    await vscode.workspace.openTextDocument('../sample.md')
     await sleep(2000)
 
     const vscodereveal = vscode.extensions.getExtension('evilz.vscode-reveal')


### PR DESCRIPTION
### Motivation

- Reduce TypeScript/ESLint noise by addressing unused variables/imports and unsafe `any` types flagged by static analysis.
- Improve type-safety in the VS Code test mock and Markdown-it renderer to avoid `any` and potential runtime issues.
- Remove stale test scaffolding and commented code to make test suites clearer and reduce false positives.

### Description

- Consume the unused Express error-handler parameter by adding `void next` to silence the "defined but never used" warning in `src/RevealServer.ts`.
- Replace `any` in the VS Code test mock with safer types (`unknown` and `void`) and tighten event/command/cancellation token signatures in `src/test/__mocks__/vscode.ts`.
- Remove an unused `TextEditorRevealType` import from `src/RevealContext.ts` and drop the unused `FrontMatterResult` import in `src/SlideParser.ts`, while explicitly consuming the `partial` parameter with `void partial` to avoid unused-argument warnings.
- Replace loose `any[]` token typing in the Markdown-it note renderer with `Token` from `markdown-it`, add null-safety checks, and update manipulation to use non-null assertions where appropriate in `src/Markdown-it.ts`.
- Clean test files by removing unused imports, eliminating commented-out test blocks, and simplifying a few test cases in `src/test/UnitTests/*` and `src/test/suite/extension.test.ts`.
- Add `/* eslint-env node */` to `jest.config.js` to address environment-related lint messages.

### Testing

- Ran `npm run -s test-compile`, which completed successfully.
- Ran unit tests with `npm test -- --runInBand src/test/UnitTests`, and all test suites passed (`14` suites, `57` tests passed).
- Attempted `npm run -s lint .`, which failed due to an ESLint configuration/plugin incompatibility (`plugin:sonarjs/recommended` contains an unexpected top-level property `name`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcc0342b8832c880c10a582d2b3f5)