### PR TITLE
Generate front matter IntelliSense metadata from configuration schema

### DIFF
--- a/src/CompletionItemProvider.ts
+++ b/src/CompletionItemProvider.ts
@@ -49,10 +49,15 @@ export const enumValueProvider = (prefix: string, values: string[]) => {
  */
 export const createCompletionItems = (configDesc: ConfigurationDescription[]) => {
   const formatValue = (value: unknown) => {
-    if (typeof value === 'string') {
-      return `"${value}"`
+    try {
+      const jsonValue = JSON.stringify(value)
+      if (jsonValue !== undefined) {
+        return jsonValue
+      }
+    } catch {
+      // Fallback for non-serializable values
     }
-    return `${value}`
+    return String(value)
   }
 
   const enumValueProviders: CompletionItemProvider[] = []

--- a/src/CompletionItemProvider.ts
+++ b/src/CompletionItemProvider.ts
@@ -48,14 +48,35 @@ export const enumValueProvider = (prefix: string, values: string[]) => {
  * `CompletionItemProvider[]`.
  */
 export const createCompletionItems = (configDesc: ConfigurationDescription[]) => {
+  const formatValue = (value: unknown) => {
+    if (typeof value === 'string') {
+      return `"${value}"`
+    }
+    return `${value}`
+  }
+
   const enumValueProviders: CompletionItemProvider[] = []
   const completionItems: CompletionItem[] =
-    configDesc.map(({ label, detail, documentation, type, values }) => {
+    configDesc.map(({ label, detail, documentation, type, values, defaultValue }) => {
       const completionItem = new CompletionItem(label)
       completionItem.kind = CompletionItemKind.Enum
-      completionItem.detail = detail
+      const metadataDetails: string[] = []
+      if (defaultValue !== undefined) {
+        metadataDetails.push(`default: ${formatValue(defaultValue)}`)
+      }
+      if (values && values.length > 0) {
+        metadataDetails.push(`enum: ${values.join(', ')}`)
+      }
+      completionItem.detail = [detail, ...metadataDetails].filter(Boolean).join(' • ')
       completionItem.filterText = label
-      completionItem.documentation = new MarkdownString(documentation)
+      const documentationLines = [documentation]
+      if (defaultValue !== undefined) {
+        documentationLines.push(`Default: \`${formatValue(defaultValue)}\``)
+      }
+      if (values && values.length > 0) {
+        documentationLines.push(`Allowed values: \`${values.join('`, `')}\``)
+      }
+      completionItem.documentation = new MarkdownString(documentationLines.filter(Boolean).join('\n\n'))
 
       switch (type) {
         case 'string':
@@ -67,6 +88,9 @@ export const createCompletionItems = (configDesc: ConfigurationDescription[]) =>
           enumValueProviders.push(enumValueProvider(label, ['true', 'false']))
           break
         case 'number':
+        case 'array':
+        case 'object':
+        case 'null':
           break
       }
 

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -97,6 +97,9 @@ export interface IExtensionOptions {
   logLevel: LogLevel
 }
 
+export const configPrefix = "revealjs"
+// Backward-compatible alias kept for existing imports.
+export const configPefix = configPrefix
 
 /** The default configuration for the Reveal.js presentation. */
 export const defaultConfiguration: Configuration = {
@@ -204,14 +207,17 @@ const normalizeType = (type: string | string[]): ConfigurationDescriptionTypes =
   if (types.includes('array')) {
     return 'array'
   }
-  if (types.includes('null')) {
-    return 'null'
-  }
   if (types.includes('number')) {
     return 'number'
   }
   if (types.includes('boolean')) {
     return 'boolean'
+  }
+  if (types.includes('string')) {
+    return 'string'
+  }
+  if (types.includes('null')) {
+    return 'null'
   }
   return 'string'
 }
@@ -221,9 +227,9 @@ export const getConfigurationDescription = (properties: Record<string, RawConfig
   const allProps: ConfigurationDescription[] =
     Object.keys(properties)
       .map(key => ({
-        label: key.startsWith(`${configPefix}.`) ? key.substring(configPefix.length + 1) : key,
+        label: key.startsWith(`${configPrefix}.`) ? key.substring(configPrefix.length + 1) : key,
         detail: properties[key].description || properties[key].markdownDescription || '',
-        documentation: properties[key].description || properties[key].markdownDescription || '',
+        documentation: properties[key].markdownDescription || properties[key].description || '',
         type: normalizeType(properties[key].type),
         values: properties[key].enum,
         defaultValue: properties[key].default
@@ -232,10 +238,8 @@ export const getConfigurationDescription = (properties: Record<string, RawConfig
   return allProps
 }
 
-export const configPefix = "revealjs"
-
 export const getConfig = () => {
-  const workspaceConfig = workspace.getConfiguration(configPefix) as unknown as Configuration
+  const workspaceConfig = workspace.getConfiguration(configPrefix) as unknown as Configuration
   return { ...defaultConfiguration, ...workspaceConfig } as Configuration
 }
 

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -179,24 +179,54 @@ export const defaultConfiguration: Configuration = {
 }
 
 
-type ConfigurationDescriptionTypes = "string" | "boolean" | "number"
+type ConfigurationDescriptionTypes = "string" | "boolean" | "number" | "array" | "object" | "null"
 export interface ConfigurationDescription {
   label: string,
   detail: string,
   documentation: string,
   type: ConfigurationDescriptionTypes,
-  values?: string[]
+  values?: string[],
+  defaultValue?: unknown
 }
-export const getConfigurationDescription = (properties: object) => {
+type RawConfigurationProperty = {
+  type: string | string[]
+  default?: unknown
+  description?: string
+  markdownDescription?: string
+  enum?: string[]
+}
+
+const normalizeType = (type: string | string[]): ConfigurationDescriptionTypes => {
+  const types = (Array.isArray(type) ? type : [type]) as string[]
+  if (types.includes('object')) {
+    return 'object'
+  }
+  if (types.includes('array')) {
+    return 'array'
+  }
+  if (types.includes('null')) {
+    return 'null'
+  }
+  if (types.includes('number')) {
+    return 'number'
+  }
+  if (types.includes('boolean')) {
+    return 'boolean'
+  }
+  return 'string'
+}
+
+export const getConfigurationDescription = (properties: Record<string, RawConfigurationProperty>) => {
 
   const allProps: ConfigurationDescription[] =
     Object.keys(properties)
       .map(key => ({
-        label: key.substring(9), // remove "revealjs."
-        detail: properties[key].description,
-        documentation: `Default value:  ${properties[key].default}`,
-        type: properties[key].type,
-        values: properties[key].enum
+        label: key.startsWith(`${configPefix}.`) ? key.substring(configPefix.length + 1) : key,
+        detail: properties[key].description || properties[key].markdownDescription || '',
+        documentation: properties[key].description || properties[key].markdownDescription || '',
+        type: normalizeType(properties[key].type),
+        values: properties[key].enum,
+        defaultValue: properties[key].default
       }))
 
   return allProps

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -40,7 +40,7 @@ import { StatusBarController } from './StatusBarController'
 import WebViewPane from './WebViewPane'
 import TextDecorator from './TextDecorator'
 import { RevealContext, RevealContexts } from './RevealContext'
-import { configPefix, Configuration, ConfigurationDescription, getConfig } from './Configuration'
+import { configPrefix, Configuration, ConfigurationDescription, getConfig } from './Configuration'
 
 const isMarkdownFile = (d: TextDocument) => d.languageId === 'markdown'
 
@@ -108,7 +108,7 @@ export default class MainController {
   }
 
   public onDidChangeConfiguration(e: ConfigurationChangeEvent) {
-    if (!e.affectsConfiguration(configPefix)) {
+    if (!e.affectsConfiguration(configPrefix)) {
       return
     }
     this.config = getConfig()

--- a/src/test/UnitTests/CompletionItemProvider.jest.ts
+++ b/src/test/UnitTests/CompletionItemProvider.jest.ts
@@ -82,3 +82,17 @@ test('Should handle number type without enum provider', () => {
     expect(enumValueProviders).toHaveLength(0)
 })
 
+test('Should stringify complex default values in completion metadata', () => {
+    const configDesc: ConfigurationDescription = {
+        label: 'obj_option',
+        detail: 'object detail',
+        documentation: 'doc',
+        type: 'object',
+        defaultValue: { enabled: true, tags: ['a', 'b'] }
+    }
+
+    const { completionItems } = createCompletionItems([configDesc])
+
+    expect(completionItems[0].detail).toBe('object detail • default: {"enabled":true,"tags":["a","b"]}')
+    expect(completionItems[0].documentation).toStrictEqual(new MarkdownString('doc\n\nDefault: `{"enabled":true,"tags":["a","b"]}`'))
+})

--- a/src/test/UnitTests/CompletionItemProvider.jest.ts
+++ b/src/test/UnitTests/CompletionItemProvider.jest.ts
@@ -11,7 +11,8 @@ test('Should createCompletionItems from configDesc', () => {
         detail: "test_detail",
         documentation: "test_documentation",
         type: "string",
-        values: ["test_values"]
+        values: ["test_values"],
+        defaultValue: "test_default"
     }
 
     const { completionItems, enumValueProviders } = createCompletionItems([configDesc])
@@ -19,8 +20,8 @@ test('Should createCompletionItems from configDesc', () => {
 
     expect(completionItems).toHaveLength(1)
     expect(completionItems[0].label).toBe("test_label")
-    expect(completionItems[0].detail).toBe("test_detail")
-    expect(completionItems[0].documentation).toStrictEqual(new MarkdownString("test_documentation"))
+    expect(completionItems[0].detail).toBe("test_detail • default: \"test_default\" • enum: test_values")
+    expect(completionItems[0].documentation).toStrictEqual(new MarkdownString("test_documentation\n\nDefault: `\"test_default\"`\n\nAllowed values: `test_values`"))
 
     expect(enumValueProviders).toHaveLength(1)
     expect(enumValueProviders[0].provideCompletionItems).toBeDefined()
@@ -80,5 +81,4 @@ test('Should handle number type without enum provider', () => {
     expect(completionItems).toHaveLength(1)
     expect(enumValueProviders).toHaveLength(0)
 })
-
 

--- a/src/test/UnitTests/Configuration.jest.ts
+++ b/src/test/UnitTests/Configuration.jest.ts
@@ -1,0 +1,36 @@
+import { getConfigurationDescription } from '../../Configuration'
+
+test('getConfigurationDescription should prefer primary type over null in unions', () => {
+  const props = {
+    'revealjs.boolOption': {
+      type: ['boolean', 'null'],
+      default: false,
+      description: 'Boolean option'
+    },
+    'revealjs.stringOption': {
+      type: ['string', 'null'],
+      default: 'value',
+      description: 'String option'
+    }
+  }
+
+  const desc = getConfigurationDescription(props)
+  expect(desc.find((x) => x.label === 'boolOption')?.type).toBe('boolean')
+  expect(desc.find((x) => x.label === 'stringOption')?.type).toBe('string')
+})
+
+test('getConfigurationDescription should keep markdown documentation when available', () => {
+  const props = {
+    'revealjs.richDoc': {
+      type: 'string',
+      default: 'x',
+      description: 'Plain text',
+      markdownDescription: '**Rich** text'
+    }
+  }
+
+  const [desc] = getConfigurationDescription(props)
+  expect(desc.label).toBe('richDoc')
+  expect(desc.detail).toBe('Plain text')
+  expect(desc.documentation).toBe('**Rich** text')
+})


### PR DESCRIPTION
### Motivation
- Improve front-matter IntelliSense by deriving metadata directly from the extension `contributes.configuration.properties` schema so completion items can show enum lists and defaults. 
- Support a wider set of schema types (`array`, `object`, `null`) and safely normalize keys that start with the `revealjs.` prefix for user-friendly labels.

### Description
- Extend `ConfigurationDescription` to include `defaultValue` and broaden `ConfigurationDescriptionTypes` to include `array`, `object`, and `null`.
- Add `RawConfigurationProperty` and `normalizeType` in `src/Configuration.ts` and change `getConfigurationDescription` to parse schema properties (type, `default`, `description`, `enum`) and emit normalized labels and defaults.
- Enrich `createCompletionItems` in `src/CompletionItemProvider.ts` to show schema-derived metadata in the completion `detail` and expanded `documentation`, add a `formatValue` helper, and keep generating enum value providers for string enums and booleans while ignoring non-enum types.
- Update unit test `src/test/UnitTests/CompletionItemProvider.jest.ts` to assert the new `detail` and `documentation` content which includes default and allowed values.

### Testing
- Ran `npm test -- --runInBand src/test/UnitTests/CompletionItemProvider.jest.ts` and the focused tests passed.
- Ran full test suite with `npm test -- --runInBand` and all tests passed (14 test suites, 57 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd7342340832cbfbaf9b997ff1bc8)