### PR TITLE
Replace timeout-based HTML export completion with explicit signal

### DIFF
--- a/src/ExportHTML.ts
+++ b/src/ExportHTML.ts
@@ -16,17 +16,9 @@ export const exportHTML = async (options: IExportOptions) => {
   const filePath = path.join(folderPath ? folderPath : ".", file)
 
   if (data) {
-    try {
-      await jetpack.writeAsync(filePath, data)
-    } catch (error) {
-      console.error(error)
-    }
+    await jetpack.writeAsync(filePath, data)
   }
   else if (srcFilePath) {
-    try {
-      await jetpack.copyAsync(srcFilePath, filePath, { overwrite: true })
-    } catch (error) {
-      console.error(error)
-    }
+    await jetpack.copyAsync(srcFilePath, filePath, { overwrite: true })
   }
 }

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -136,7 +136,8 @@ export default class MainController {
       logger,
       () => this.config,
       extensionContext.extensionPath,
-      this.isInExport
+      this.isInExport,
+      this.onExportError
     )
     this.diagnostics = languages.createDiagnosticCollection('vscode-revealjs')
     this.configByKey = new Map(configDesc.map((d) => [d.label, d]))
@@ -159,23 +160,41 @@ export default class MainController {
   }
   //#endregion
 
-  // active export during 5 seconds
-  private exportTimeout: NodeJS.Timeout | null = null
-  public isInExport = () => this.exportTimeout != null && this.exportTimeout != undefined
+  private exportState: {
+    resolve: (path: string) => void
+    reject: (error: Error) => void
+    path: string
+  } | null = null
+  public isInExport = () => this.exportState !== null
+
+  private readonly onExportError = (error: unknown) => {
+    if (!this.exportState) return
+
+    const normalizedError = error instanceof Error ? error : new Error(String(error))
+    this.exportState.reject(new Error(`HTML export failed: ${normalizedError.message}`))
+    this.exportState = null
+  }
 
   public shouldOpenFilemanagerAfterHTMLExport = () => this.currentContext?.configuration.openFilemanagerAfterHTMLExport ?? false
 
 
   public exportAsync = async () => {
-    if (this.exportTimeout) {
-      clearTimeout(this.exportTimeout)
+    if (!this.currentContext) {
+      throw new Error('No active markdown context to export')
     }
-    if (this.currentContext) { await jetpack.removeAsync(this.currentContext.exportPath) }
 
-    const promise = new Promise<string>((resolve) => {
-      this.exportTimeout = setTimeout(() => resolve(this.currentContext?.exportPath ?? ''), 5000)
+    if (this.exportState) {
+      this.exportState.reject(new Error('A previous HTML export was interrupted by a new export request'))
+      this.exportState = null
+    }
+
+    await jetpack.removeAsync(this.currentContext.exportPath)
+    const exportPath = this.currentContext.exportPath
+
+    const promise = new Promise<string>((resolve, reject) => {
+      this.exportState = { resolve, reject, path: exportPath }
     })
-    //await commands.executeCommand(SHOW_REVEALJS_IN_BROWSER)
+
     this.webViewPane ? this.refreshWebViewPane() : await commands.executeCommand(SHOW_REVEALJS)
 
     return promise
@@ -264,6 +283,14 @@ export default class MainController {
         if (!message || typeof message !== 'object') return
 
         const command = 'command' in message ? message.command : undefined
+        if (command === 'exportComplete') {
+          if (this.exportState) {
+            this.exportState.resolve(this.exportState.path)
+            this.exportState = null
+          }
+          return
+        }
+
         if (command !== 'slideChanged') return
 
         const horizontal = 'horizontal' in message ? Number(message.horizontal) : Number.NaN
@@ -284,7 +311,7 @@ export default class MainController {
     if (this.webViewPane && this.currentContext) {
       this.startServer()
       this.webViewPane.title = this.currentContext.configuration.title
-      void this.webViewPane.update(this.currentContext.uriWithPosition)
+      void this.webViewPane.update(this.currentContext.uriWithPosition, this.isInExport())
     }
   }
 

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -29,7 +29,8 @@ export class RevealContext extends Disposable {
     public logger: Logger,
     public getConfiguration: () => Configuration,
     public extensionPath: string,
-    public isInExport: () => boolean
+    public isInExport: () => boolean,
+    public onExportError: (error: unknown) => void = () => {}
   ) {
     super()
     this.editor = editor
@@ -170,14 +171,15 @@ export class RevealContexts {
     private readonly logger: Logger,
     private readonly getConfiguration: () => Configuration,
     private readonly extensionPath: string,
-    private readonly isInExport: () => boolean
+    private readonly isInExport: () => boolean,
+    private readonly onExportError: (error: unknown) => void
   ) {
     this.logger = logger
   }
 
   getOrAdd(editor: TextEditor) {
     if (this.innerMap.has(editor.document.uri)) return this.innerMap.get(editor.document.uri)
-    const context = new RevealContext(editor, this.logger, this.getConfiguration, this.extensionPath, this.isInExport)
+    const context = new RevealContext(editor, this.logger, this.getConfiguration, this.extensionPath, this.isInExport, this.onExportError)
 
     context.onDidDispose(() => this.logger.info(`CONTEXT: ${editor.document.uri} disposed`))
 

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -178,7 +178,8 @@ export class RevealServer extends Disposable {
             const opts: IExportOptions = { folderPath: exportPath, url: req.originalUrl.split('?')[0], srcFilePath: null, data: body }
             await exportfn(opts)
           } catch (error) {
-            this.context.logger.info(`Error : ${error}`)
+            this.context.logger.error(`Export error: ${error}`)
+            this.context.onExportError(error)
           }
 
           // @ts-ignore

--- a/src/WebViewPane.ts
+++ b/src/WebViewPane.ts
@@ -36,7 +36,7 @@ export default class WebviewPane
         this.webviewPanel.title = title;
     }
     
-    public async update(url:string) {
+    public async update(url:string, sendExportSignal = false) {
         const parsedUrl = new URL(url)
         const slideHash = parsedUrl.hash || '#/'
         parsedUrl.hash = ''
@@ -44,7 +44,7 @@ export default class WebviewPane
         const response = await fetch(parsedUrl.toString())
         const html = await response.text()
         const htmlWithBase = this.injectBaseHref(html, parsedUrl.toString())
-        this.webviewPanel.webview.html = this.injectBridgeScript(htmlWithBase, slideHash)
+        this.webviewPanel.webview.html = this.injectBridgeScript(htmlWithBase, slideHash, sendExportSignal)
         this.#onDidUpdate.fire()
     }
 
@@ -57,7 +57,7 @@ export default class WebviewPane
       return `${baseTag}${html}`
     }
 
-    private injectBridgeScript(html: string, slideHash: string) {
+    private injectBridgeScript(html: string, slideHash: string, sendExportSignal: boolean) {
       const script = `
       <script>
         (function () {
@@ -93,6 +93,12 @@ export default class WebviewPane
           }
 
           setTimeout(postCurrentSlide, 0);
+
+          if (${sendExportSignal}) {
+            window.addEventListener('load', () => {
+              vscode.postMessage({ command: 'exportComplete' });
+            }, { once: true });
+          }
         }());
       </script>
       `

--- a/src/WebViewPane.ts
+++ b/src/WebViewPane.ts
@@ -95,9 +95,15 @@ export default class WebviewPane
           setTimeout(postCurrentSlide, 0);
 
           if (${sendExportSignal}) {
-            window.addEventListener('load', () => {
+            const postExportComplete = () => {
               vscode.postMessage({ command: 'exportComplete' });
-            }, { once: true });
+            };
+
+            if (document.readyState === 'complete') {
+              postExportComplete();
+            } else {
+              window.addEventListener('load', postExportComplete, { once: true });
+            }
           }
         }());
       </script>

--- a/src/commands/exportHTML.ts
+++ b/src/commands/exportHTML.ts
@@ -7,7 +7,8 @@ export const EXPORT_HTML = 'vscode-revealjs.exportHTML'
 export type EXPORT_HTML = typeof EXPORT_HTML
 
 export const exportHTML = (logger: Logger, startExport: () => Promise<string>, doOpenAfterExport: () => boolean) => async () => {
-  await window.withProgress(
+  try {
+    await window.withProgress(
     {
       location: ProgressLocation.Notification,
       title: 'Export',
@@ -27,6 +28,12 @@ export const exportHTML = (logger: Logger, startExport: () => Promise<string>, d
       }
     }
   )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error(`Export failed: ${message}`)
+    void window.showErrorMessage(`RevealJS HTML export failed: ${message}`)
+    throw error
+  }
 }
 
 function timeout(ms) {


### PR DESCRIPTION
### Motivation
- The HTML export relied on a fixed 5s timeout to consider an export complete, which can produce false-positives or hide real errors (issue #1403).
- Exposed filesystem errors were being swallowed during the export pipeline instead of rejecting the export operation.

### Description
- Removed the 5s timer and implemented an explicit export session in `MainController`: `exportState` holds resolve/reject and the export now completes only when a `exportComplete` message is received from the webview.
- Updated `WebViewPane.update()` to accept a `sendExportSignal` flag and inject a bridge snippet that posts `exportComplete` on the page `load` event when exporting.
- Threaded an `onExportError` callback through `RevealContext` / `RevealContexts` and invoked it from `RevealServer` when `ExportHTML` fails, so the controller can reject the export promise on real failures.
- Stopped silently swallowing write/copy errors in `ExportHTML.ts` (removed internal try/catch) and added user-visible failure handling in the `exportHTML` command (`window.showErrorMessage`) so errors are logged and rethrown.
- Key files changed: `src/MainController.ts`, `src/WebViewPane.ts`, `src/RevealServer.ts`, `src/RevealContext.ts`, `src/ExportHTML.ts`, `src/commands/exportHTML.ts`.

### Testing
- Ran `npm test -- --runInBand`, which completed successfully: 16 test suites, 63 tests, all passed.
- Ran `npm run test-compile` (`tsc -p ./`), which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc88fa0558832c9e75f381273d4a73)