### PR TITLE
Add configuration contract tests and align runtime defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ In this mode, diagram code blocks are kept as plain code blocks and no remote di
 
 You can customize many setting on for your reveal.js presentation.
 
+Configuration contract notes (validated by unit tests):
+- Runtime-only/frontmatter options: `author`, `autoPlayMedia`, `customHighlightTheme`, `customTheme`, `defaultTiming`, `description`, `display`, `enableTitleFooter`, `fragmentInURL`, `logLevel`, `logoImg`, `notesSeparator`, `separator`, `verticalSeparator`.
+- VS Code-contributed only options: `hashOneBasedIndex`, `showSlideNumber`.
+
 <table><tr><th>Name</th><th>Description</th><th>Default</th></tr><tr><td><code>revealjs.notesSeparator</code></td><td>Revealjs markdown note delimiter</td><td><code>note:</code></td></tr><tr><td><code>revealjs.separator</code></td><td>Revealjs markdown slide separator</td><td><code>^(
 ?|
 )---(

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -145,9 +145,9 @@ export const defaultConfiguration: Configuration = {
   mouseWheel: false,
   hideAddressBar: true,
   previewLinks: false,
-  transition: 'default',
+  transition: 'slide',
   transitionSpeed: 'default',
-  backgroundTransition: 'default',
+  backgroundTransition: 'fade',
   viewDistance: 3,
 
   width: 960,

--- a/src/test/UnitTests/Configuration.jest.ts
+++ b/src/test/UnitTests/Configuration.jest.ts
@@ -1,4 +1,43 @@
-import { getConfigurationDescription } from '../../Configuration'
+import { defaultConfiguration, configPrefix, getConfigurationDescription } from '../../Configuration'
+
+const packageJson = require('../../../package.json')
+
+type ContributedProperty = {
+  default?: unknown
+}
+
+const contributedProperties = packageJson.contributes.configuration.properties as Record<string, ContributedProperty>
+
+const getContributedKey = (key: string) => key.replace(`${configPrefix}.`, '')
+
+const contributedRevealKeys = Object.keys(contributedProperties)
+  .filter((key) => key.startsWith(`${configPrefix}.`))
+  .map(getContributedKey)
+
+const runtimeKeys = Object.keys(defaultConfiguration)
+
+// Runtime-only keys are still supported via frontmatter or internal extension behavior.
+const intentionallyRuntimeOnlyKeys = [
+  'author',
+  'autoPlayMedia',
+  'customHighlightTheme',
+  'customTheme',
+  'defaultTiming',
+  'description',
+  'display',
+  'enableTitleFooter',
+  'fragmentInURL',
+  'logLevel',
+  'logoImg',
+  'notesSeparator',
+  'separator',
+  'verticalSeparator'
+]
+
+// VS Code-contributed keys that intentionally have no runtime defaults in this extension.
+const intentionallyContributedOnlyKeys = ['hashOneBasedIndex', 'showSlideNumber']
+
+const stableStringify = (value: unknown) => JSON.stringify(value)
 
 test('getConfigurationDescription should prefer primary type over null in unions', () => {
   const props = {
@@ -67,4 +106,30 @@ test('getConfigurationDescription should keep markdown documentation when availa
   expect(desc.label).toBe('richDoc')
   expect(desc.detail).toBe('Plain text')
   expect(desc.documentation).toBe('**Rich** text')
+})
+
+describe('configuration contract tests', () => {
+  test('runtime-only keys remain intentional and documented', () => {
+    const runtimeOnlyKeys = runtimeKeys
+      .filter((key) => !contributedRevealKeys.includes(key))
+      .sort()
+
+    expect(runtimeOnlyKeys).toEqual(intentionallyRuntimeOnlyKeys.sort())
+  })
+
+  test('contributed-only keys remain intentional and documented', () => {
+    const contributedOnlyKeys = contributedRevealKeys
+      .filter((key) => !runtimeKeys.includes(key))
+      .sort()
+
+    expect(contributedOnlyKeys).toEqual(intentionallyContributedOnlyKeys.sort())
+  })
+
+  test('shared keys keep aligned default values between package.json and runtime defaults', () => {
+    const defaultMismatches = contributedRevealKeys
+      .filter((key) => runtimeKeys.includes(key))
+      .filter((key) => stableStringify(contributedProperties[`${configPrefix}.${key}`].default) !== stableStringify(defaultConfiguration[key]))
+
+    expect(defaultMismatches).toEqual([])
+  })
 })

--- a/src/test/UnitTests/Configuration.jest.ts
+++ b/src/test/UnitTests/Configuration.jest.ts
@@ -37,7 +37,7 @@ const intentionallyRuntimeOnlyKeys = [
 // VS Code-contributed keys that intentionally have no runtime defaults in this extension.
 const intentionallyContributedOnlyKeys = ['hashOneBasedIndex', 'showSlideNumber']
 
-const stableStringify = (value: unknown) => JSON.stringify(value)
+const stringify = (value: unknown) => JSON.stringify(value)
 
 test('getConfigurationDescription should prefer primary type over null in unions', () => {
   const props = {
@@ -114,7 +114,7 @@ describe('configuration contract tests', () => {
       .filter((key) => !contributedRevealKeys.includes(key))
       .sort()
 
-    expect(runtimeOnlyKeys).toEqual(intentionallyRuntimeOnlyKeys.sort())
+    expect(runtimeOnlyKeys).toEqual([...intentionallyRuntimeOnlyKeys].sort())
   })
 
   test('contributed-only keys remain intentional and documented', () => {
@@ -122,13 +122,13 @@ describe('configuration contract tests', () => {
       .filter((key) => !runtimeKeys.includes(key))
       .sort()
 
-    expect(contributedOnlyKeys).toEqual(intentionallyContributedOnlyKeys.sort())
+    expect(contributedOnlyKeys).toEqual([...intentionallyContributedOnlyKeys].sort())
   })
 
   test('shared keys keep aligned default values between package.json and runtime defaults', () => {
     const defaultMismatches = contributedRevealKeys
       .filter((key) => runtimeKeys.includes(key))
-      .filter((key) => stableStringify(contributedProperties[`${configPrefix}.${key}`].default) !== stableStringify(defaultConfiguration[key]))
+      .filter((key) => stringify(contributedProperties[`${configPrefix}.${key}`].default) !== stringify(defaultConfiguration[key]))
 
     expect(defaultMismatches).toEqual([])
   })


### PR DESCRIPTION
### Motivation
- Prevent accidental drift between VS Code-contributed configuration in `package.json` and the extension runtime defaults by adding automated checks. 
- Align runtime defaults with the contributed schema where they unintentionally diverged to keep behavior predictable. 
- Make intentional differences explicit in documentation so future changes are auditable and testable.

### Description
- Add a configuration contract test suite at `src/test/UnitTests/Configuration.jest.ts` that verifies runtime-only keys, contributed-only keys, and parity of shared default values. 
- Update runtime defaults in `src/Configuration.ts` to set `transition` to `'slide'` and `backgroundTransition` to `'fade'` to match `package.json`. 
- Document the intentional runtime-only and contributed-only configuration differences in `README.md` under the options section.

### Testing
- Ran `npm test -- src/test/UnitTests/Configuration.jest.ts`, which passed (7 tests across the new suite). 
- Ran `npm run test-compile` (`tsc`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ec64278c832c8332452e5ab8d20c)