### PR TITLE
test: replace placeholder with parser/preview/export unit tests

### DIFF
--- a/src/test/UnitTests/NotTestedYet.jest.ts
+++ b/src/test/UnitTests/NotTestedYet.jest.ts
@@ -1,4 +1,0 @@
-test('NOTHING HERE', () => {
-
-    expect(true).toBeTruthy()
-  }) 

--- a/src/test/UnitTests/WebviewPane.jest.ts
+++ b/src/test/UnitTests/WebviewPane.jest.ts
@@ -1,50 +1,64 @@
-import WebviewPane from "../../WebViewPane"
-import {Event, WebviewPanel} from "vscode"
+import WebviewPane from '../../WebViewPane'
+import { Event, WebviewPanel } from 'vscode'
 
 test('Set title of webviewpane', () => {
+  const onDidDispose = jest.fn() as Event<void>
+  const onDidReceiveMessage = jest.fn() as Event<unknown>
+  const webviewPanel = { title: 'test', onDidDispose: onDidDispose, webview: { html: '', onDidReceiveMessage } } as unknown as WebviewPanel
+  const pane = new WebviewPane(webviewPanel)
+  pane.title = 'new title'
 
-    const onDidDispose = jest.fn( ) as Event<void>
-    const onDidReceiveMessage = jest.fn() as Event<unknown>
-    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, webview: { html: "", onDidReceiveMessage } }  as unknown as WebviewPanel 
-    const pane = new WebviewPane( webviewPanel )
-    pane.title = "new title"
-  
-    expect(webviewPanel.title).toBe("new title")
+  expect(webviewPanel.title).toBe('new title')
+})
+
+test('Dispose should trigger onDidDispose', () => {
+  const onDidDispose = jest.fn() as Event<void>
+  const onDidReceiveMessage = jest.fn() as Event<unknown>
+  const dispose = jest.fn() as () => unknown
+  const webviewPanel = { title: 'test', onDidDispose: onDidDispose, dispose: dispose, webview: { html: '', onDidReceiveMessage } } as unknown as WebviewPanel
+  const pane = new WebviewPane(webviewPanel)
+
+  const onDidDisposeFn = jest.fn()
+  pane.onDidDispose(onDidDisposeFn)
+
+  pane.dispose()
+
+  expect(onDidDispose).toHaveBeenCalledTimes(1)
+  expect(onDidDisposeFn).toHaveBeenCalledTimes(1)
+})
+
+test('Update should trigger onDidUpdate', async () => {
+  const onDidDispose = jest.fn() as Event<void>
+  const onDidReceiveMessage = jest.fn() as Event<unknown>
+  const dispose = jest.fn() as () => unknown
+  const webviewPanel = { title: 'test', onDidDispose: onDidDispose, dispose: dispose, webview: { html: '', onDidReceiveMessage } } as unknown as WebviewPanel
+  const pane = new WebviewPane(webviewPanel)
+  ;(global as unknown as { fetch: jest.Mock }).fetch = jest.fn().mockResolvedValue({
+    text: jest.fn().mockResolvedValue('<html><head></head><body>hello</body></html>'),
   })
 
+  const onDidUpdate = jest.fn()
+  pane.onDidUpdate(onDidUpdate)
+  await pane.update('http://localhost:1234/#/1/2')
 
-  test('Dispose should trigger onDidDispose', () => {
+  expect(onDidUpdate).toHaveBeenCalledTimes(1)
+})
 
-    const onDidDispose = jest.fn( ) as Event<void>
-    const onDidReceiveMessage = jest.fn() as Event<unknown>
-    const dispose = jest.fn() as (()=>unknown)
-    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, dispose : dispose, webview: { html: "", onDidReceiveMessage } }  as unknown as WebviewPanel 
-    const pane = new WebviewPane( webviewPanel )
-  
-    const onDidDisposeFn = jest.fn()
-    pane.onDidDispose(onDidDisposeFn)
+test('Update injects bridge script for slide sync and preserves hash with query params', async () => {
+  const onDidDispose = jest.fn() as Event<void>
+  const onDidReceiveMessage = jest.fn() as Event<unknown>
+  const webviewPanel = { title: 'test', onDidDispose: onDidDispose, webview: { html: '', onDidReceiveMessage } } as unknown as WebviewPanel
+  const pane = new WebviewPane(webviewPanel)
 
-    pane.dispose()
-    
-    expect(onDidDispose).toHaveBeenCalledTimes(1)
-    expect(onDidDisposeFn).toHaveBeenCalledTimes(1)
+  ;(global as unknown as { fetch: jest.Mock }).fetch = jest.fn().mockResolvedValue({
+    text: jest.fn().mockResolvedValue('<html><head></head><body><div>hello</div></body></html>'),
   })
 
+  await pane.update('http://localhost:1234/?print-pdf#/2/1', true)
 
-  test('Update should trigger onDidUpdate', async () => {
-
-    const onDidDispose = jest.fn( ) as Event<void>
-    const onDidReceiveMessage = jest.fn() as Event<unknown>
-    const dispose = jest.fn() as (()=> unknown)
-    const webviewPanel = {title: "test" , onDidDispose: onDidDispose, dispose : dispose, webview: {html:"", onDidReceiveMessage} }  as unknown as WebviewPanel 
-    const pane = new WebviewPane( webviewPanel )
-    ;(global as unknown as { fetch: jest.Mock }).fetch = jest.fn().mockResolvedValue({
-      text: jest.fn().mockResolvedValue('<html><head></head><body>hello</body></html>')
-    })
-  
-    const onDidUpdate = jest.fn()
-    pane.onDidUpdate(onDidUpdate)
-    await pane.update("http://localhost:1234/#/1/2")
-    
-    expect(onDidUpdate).toHaveBeenCalledTimes(1)
-  })
+  expect(webviewPanel.webview.html).toContain('<base href="http://localhost:1234/?print-pdf">')
+  expect(webviewPanel.webview.html).toContain("command: 'slideChanged'")
+  expect(webviewPanel.webview.html).toContain("message.command === 'setSlide'")
+  expect(webviewPanel.webview.html).toContain('window.location.hash = initialHash')
+  expect(webviewPanel.webview.html).toContain("command: 'exportComplete'")
+})

--- a/src/test/UnitTests/WebviewPane.jest.ts
+++ b/src/test/UnitTests/WebviewPane.jest.ts
@@ -1,6 +1,21 @@
 import WebviewPane from '../../WebViewPane'
 import { Event, WebviewPanel } from 'vscode'
 
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+
+const mockFetch = (html: string) => {
+  if (!global.fetch) {
+    ;(global as unknown as { fetch: typeof fetch }).fetch = (() => Promise.resolve({ text: async () => '' } as unknown as Response)) as typeof fetch
+  }
+
+  return jest.spyOn(global, 'fetch').mockResolvedValue({
+    text: jest.fn().mockResolvedValue(html),
+  } as unknown as Response)
+}
+
 test('Set title of webviewpane', () => {
   const onDidDispose = jest.fn() as Event<void>
   const onDidReceiveMessage = jest.fn() as Event<unknown>
@@ -33,9 +48,7 @@ test('Update should trigger onDidUpdate', async () => {
   const dispose = jest.fn() as () => unknown
   const webviewPanel = { title: 'test', onDidDispose: onDidDispose, dispose: dispose, webview: { html: '', onDidReceiveMessage } } as unknown as WebviewPanel
   const pane = new WebviewPane(webviewPanel)
-  ;(global as unknown as { fetch: jest.Mock }).fetch = jest.fn().mockResolvedValue({
-    text: jest.fn().mockResolvedValue('<html><head></head><body>hello</body></html>'),
-  })
+  mockFetch('<html><head></head><body>hello</body></html>')
 
   const onDidUpdate = jest.fn()
   pane.onDidUpdate(onDidUpdate)
@@ -50,9 +63,7 @@ test('Update injects bridge script for slide sync and preserves hash with query 
   const webviewPanel = { title: 'test', onDidDispose: onDidDispose, webview: { html: '', onDidReceiveMessage } } as unknown as WebviewPanel
   const pane = new WebviewPane(webviewPanel)
 
-  ;(global as unknown as { fetch: jest.Mock }).fetch = jest.fn().mockResolvedValue({
-    text: jest.fn().mockResolvedValue('<html><head></head><body><div>hello</div></body></html>'),
-  })
+  mockFetch('<html><head></head><body><div>hello</div></body></html>')
 
   await pane.update('http://localhost:1234/?print-pdf#/2/1', true)
 

--- a/src/test/UnitTests/exportHTML.jest.ts
+++ b/src/test/UnitTests/exportHTML.jest.ts
@@ -22,16 +22,27 @@ describe('exportHTML command', () => {
   const logger = new Logger(jest.fn(), LogLevel.Debug)
 
   beforeEach(() => {
+    jest.useFakeTimers()
     jest.clearAllMocks()
     withProgressMock.mockImplementation(async (_options, task) => task({ report: jest.fn() }))
     openFolderMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
   })
 
   test('runs export and opens folder when configured', async () => {
     const startExport = jest.fn().mockResolvedValue('/tmp/exported')
     const command = exportHTML(logger, startExport, () => true)
 
-    await command()
+    const commandPromise = command()
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+      jest.advanceTimersByTime(1500)
+    }
+    await commandPromise
 
     expect(startExport).toHaveBeenCalledTimes(1)
     expect(openFolderMock).toHaveBeenCalledWith('/tmp/exported')

--- a/src/test/UnitTests/exportHTML.jest.ts
+++ b/src/test/UnitTests/exportHTML.jest.ts
@@ -1,0 +1,50 @@
+const withProgressMock = jest.fn()
+const showErrorMessageMock = jest.fn()
+
+jest.mock('vscode', () => ({
+  ProgressLocation: { Notification: 15 },
+  window: {
+    withProgress: (...args: unknown[]) => withProgressMock(...args),
+    showErrorMessage: (...args: unknown[]) => showErrorMessageMock(...args),
+  },
+}))
+
+const openFolderMock = jest.fn()
+
+jest.mock('../../commands/openExternal', () => ({
+  openFolder: (...args: unknown[]) => openFolderMock(...args),
+}))
+
+import Logger, { LogLevel } from '../../Logger'
+import { exportHTML } from '../../commands/exportHTML'
+
+describe('exportHTML command', () => {
+  const logger = new Logger(jest.fn(), LogLevel.Debug)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    withProgressMock.mockImplementation(async (_options, task) => task({ report: jest.fn() }))
+    openFolderMock.mockResolvedValue(undefined)
+  })
+
+  test('runs export and opens folder when configured', async () => {
+    const startExport = jest.fn().mockResolvedValue('/tmp/exported')
+    const command = exportHTML(logger, startExport, () => true)
+
+    await command()
+
+    expect(startExport).toHaveBeenCalledTimes(1)
+    expect(openFolderMock).toHaveBeenCalledWith('/tmp/exported')
+    expect(showErrorMessageMock).not.toHaveBeenCalled()
+  })
+
+  test('surfaces export errors to the user and rethrows', async () => {
+    const startExportError = new Error('broken')
+    const startExport = jest.fn().mockRejectedValue(startExportError)
+    const command = exportHTML(logger, startExport, () => false)
+
+    await expect(command()).rejects.toThrow('broken')
+    expect(showErrorMessageMock).toHaveBeenCalledWith('RevealJS HTML export failed: broken')
+    expect(openFolderMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/test/UnitTests/slideparser.jest.ts
+++ b/src/test/UnitTests/slideparser.jest.ts
@@ -1,9 +1,8 @@
 import { countLines, countLinesToSlide } from '../../utils'
 import parser from '../../SlideParser'
-import {defaultConfiguration} from "../../Configuration"
+import { defaultConfiguration } from '../../Configuration'
 
 // const sampleFile = fs.readFileSync('../sample.md').toString()
-
 
 const slideContent = `# Title One
 
@@ -29,7 +28,7 @@ content !
 
 ## Sub Two`
 
-const { slides} = parser.parse(slideContent, defaultConfiguration)
+const { slides } = parser.parse(slideContent, defaultConfiguration)
 
 test('Parse Slide content', () => {
   expect(slides.length).toBe(3)
@@ -141,7 +140,7 @@ test('Extract slide attributes', () => {
   const content = `<!-- .slide: class="toto" data-something -->
 # title`
 
-  const {slides} = parser.parse(content,defaultConfiguration)
+  const { slides } = parser.parse(content, defaultConfiguration)
 
   expect(slides[0]).toEqual({
     index: 0,
@@ -151,4 +150,25 @@ test('Extract slide attributes', () => {
     verticalChildren: [],
     attributes: 'class="toto" data-something',
   })
+})
+
+test('Malformed front matter still returns parsed slides and parser location', () => {
+  const malformedFrontMatter = `---
+foo: [
+---
+# Slide one`
+
+  const result = parser.parse(malformedFrontMatter, defaultConfiguration)
+
+  expect(result.frontmatter).toBeUndefined()
+  expect(result.slides).toHaveLength(1)
+  expect(result.slides[0].title).toBe('---')
+  expect(result.slides[0].text).toContain('# Slide one')
+  expect(result.parseError).toEqual(
+    expect.objectContaining({
+      line: expect.any(Number),
+      column: expect.any(Number),
+      message: expect.any(String),
+    })
+  )
 })


### PR DESCRIPTION
### Motivation
- Remove a placeholder/no-op test and provide real unit coverage for slide parsing, preview webview behavior, and the HTML export command to prevent regressions.
- Verify malformed front-matter handling so parsing still returns slides plus structured parse error metadata.
- Ensure the webview injection/bridge logic and export flow produce the expected HTML and user-visible behavior.

### Description
- Deleted the placeholder `src/test/UnitTests/NotTestedYet.jest.ts` and added focused tests to cover real functionality.
- Extended `src/test/UnitTests/slideparser.jest.ts` with a regression case that asserts malformed front-matter yields parsed slides and a `parseError` containing `line`, `column`, and `message` fields.
- Updated `src/test/UnitTests/WebviewPane.jest.ts` to assert the preview HTML includes a `<base>` tag for query-preserving URLs, the bridge script that posts `slideChanged` messages, the message handler check for `message.command === 'setSlide'`, and the `exportComplete` signaling logic.
- Added `src/test/UnitTests/exportHTML.jest.ts` to mock `vscode.window.withProgress` and `openFolder` and to test successful export + open-folder behavior as well as error propagation and user-facing error messaging.

### Testing
- Ran `npm test -- src/test/UnitTests/slideparser.jest.ts src/test/UnitTests/WebviewPane.jest.ts src/test/UnitTests/exportHTML.jest.ts` and all three suites passed. 
- Test run summary: 3 test suites passed, 20 tests passed. 
- These tests validate parsing (including malformed front matter), webview bridge injection and hash preservation, and export command success/error handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3faf8961c832caa0021077b4c1877)