### PR TITLE
Add unit tests for exportPDF and extension activation (addresses #1430)

### DIFF
--- a/src/test/UnitTests/exportPDF.jest.ts
+++ b/src/test/UnitTests/exportPDF.jest.ts
@@ -1,0 +1,37 @@
+const openInBrowserMock = jest.fn()
+
+jest.mock('../../commands/openExternal', () => ({
+  openInBrowser: (...args: unknown[]) => openInBrowserMock(...args),
+}))
+
+import { exportPDF } from '../../commands/exportPDF'
+
+describe('exportPDF command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('does nothing when server URI is undefined', async () => {
+    const command = exportPDF(() => undefined, () => '/custom/browser')
+
+    await command()
+
+    expect(openInBrowserMock).not.toHaveBeenCalled()
+  })
+
+  test('opens print URL in configured browser', async () => {
+    const command = exportPDF(() => 'http://localhost:1948', () => ' /custom/browser ')
+
+    await command()
+
+    expect(openInBrowserMock).toHaveBeenCalledWith('http://localhost:1948?print-pdf-now', ' /custom/browser ')
+  })
+
+  test('opens print URL with default browser when no path provider is given', async () => {
+    const command = exportPDF(() => 'http://localhost:1948')
+
+    await command()
+
+    expect(openInBrowserMock).toHaveBeenCalledWith('http://localhost:1948?print-pdf-now', undefined)
+  })
+})

--- a/src/test/UnitTests/extension.jest.ts
+++ b/src/test/UnitTests/extension.jest.ts
@@ -128,7 +128,13 @@ describe('extension activate', () => {
     activate(context as any)
 
     expect(createOutputChannelMock).toHaveBeenCalledWith('RevealJS')
-    expect(MainControllerMock).toHaveBeenCalled()
+    expect(MainControllerMock).toHaveBeenCalledWith(
+      expect.anything(),
+      context,
+      ['config-desc'],
+      { logLevel: 2, slideExplorerEnabled: true },
+      undefined
+    )
     expect(executeCommandMock).toHaveBeenCalledWith('setContext', 'slideExplorerEnabled', true)
 
     expect(registerCommandMock).toHaveBeenCalledWith('vscode-revealjs.showRevealJS', expect.any(Function))

--- a/src/test/UnitTests/extension.jest.ts
+++ b/src/test/UnitTests/extension.jest.ts
@@ -143,6 +143,6 @@ describe('extension activate', () => {
 
     jest.advanceTimersByTime(500)
     expect(mainControllerInstance.refresh).toHaveBeenCalledWith(0)
-    expect((context as any).subscriptions.length).toBeGreaterThan(0)
+    expect((context as any).subscriptions.length).toBe(16)
   })
 })

--- a/src/test/UnitTests/extension.jest.ts
+++ b/src/test/UnitTests/extension.jest.ts
@@ -1,0 +1,148 @@
+const createOutputChannelMock = jest.fn(() => ({ appendLine: jest.fn() }))
+const executeCommandMock = jest.fn()
+const registerCommandMock = jest.fn((name: string, callback: (...args: unknown[]) => unknown) => ({ name, callback, dispose: jest.fn() }))
+const onDidChangeTextEditorSelectionMock = jest.fn(() => ({ dispose: jest.fn() }))
+const onDidChangeActiveTextEditorMock = jest.fn(() => ({ dispose: jest.fn() }))
+const onDidChangeTextDocumentMock = jest.fn(() => ({ dispose: jest.fn() }))
+const onDidSaveTextDocumentMock = jest.fn(() => ({ dispose: jest.fn() }))
+const onDidCloseTextDocumentMock = jest.fn(() => ({ dispose: jest.fn() }))
+const onDidChangeConfigurationMock = jest.fn(() => ({ dispose: jest.fn() }))
+
+const showRevealJSInBrowserMock = jest.fn(() => jest.fn())
+const showRevealJSPresenterViewMock = jest.fn(() => jest.fn())
+const exportPDFMock = jest.fn(() => jest.fn())
+const exportHTMLMock = jest.fn(() => jest.fn())
+const showSampleMock = jest.fn()
+const createPresentationFromTemplateMock = jest.fn()
+const languageCompletionMock = jest.fn(() => [{ dispose: jest.fn() }])
+
+const getConfigMock = jest.fn(() => ({ logLevel: 2, slideExplorerEnabled: true }))
+const getConfigurationDescriptionMock = jest.fn(() => ['config-desc'])
+
+const mainControllerInstance = {
+  currentContext: {
+    startServer: jest.fn(() => 'http://localhost:1948'),
+    configuration: { browserPath: '/custom/browser' },
+  },
+  showWebViewPane: jest.fn(),
+  stopServer: jest.fn(),
+  goToSlide: jest.fn(),
+  onDidChangeTextEditorSelection: jest.fn(),
+  onDidChangeActiveTextEditor: jest.fn(),
+  onDidChangeTextDocument: jest.fn(),
+  onDidSaveTextDocument: jest.fn(),
+  onDidCloseTextDocument: jest.fn(),
+  onDidChangeConfiguration: jest.fn(),
+  refresh: jest.fn(),
+  exportAsync: jest.fn(),
+  shouldOpenFilemanagerAfterHTMLExport: jest.fn(() => true),
+}
+
+const MainControllerMock = jest.fn(() => mainControllerInstance)
+
+jest.mock('vscode', () => ({
+  commands: {
+    executeCommand: (command: string, ...rest: unknown[]) => (executeCommandMock as any)(command, ...rest),
+    registerCommand: (name: string, callback: (...args: unknown[]) => unknown) => (registerCommandMock as any)(name, callback),
+  },
+  window: {
+    createOutputChannel: (name: string) => (createOutputChannelMock as any)(name),
+    activeTextEditor: undefined,
+    onDidChangeTextEditorSelection: (listener: unknown) => (onDidChangeTextEditorSelectionMock as any)(listener),
+    onDidChangeActiveTextEditor: (listener: unknown) => (onDidChangeActiveTextEditorMock as any)(listener),
+  },
+  workspace: {
+    onDidChangeTextDocument: (listener: unknown) => (onDidChangeTextDocumentMock as any)(listener),
+    onDidSaveTextDocument: (listener: unknown) => (onDidSaveTextDocumentMock as any)(listener),
+    onDidCloseTextDocument: (listener: unknown) => (onDidCloseTextDocumentMock as any)(listener),
+    onDidChangeConfiguration: (listener: unknown) => (onDidChangeConfigurationMock as any)(listener),
+  },
+}))
+
+jest.mock('../../commands/showRevealJSInBrowser', () => ({
+  SHOW_REVEALJS_IN_BROWSER: 'showInBrowser',
+  SHOW_REVEALJS_PRESENTER_VIEW: 'presenterView',
+  showRevealJSInBrowser: (startServer: unknown, getBrowserPath: unknown) => (showRevealJSInBrowserMock as any)(startServer, getBrowserPath),
+  showRevealJSPresenterView: (startServer: unknown, getBrowserPath: unknown) => (showRevealJSPresenterViewMock as any)(startServer, getBrowserPath),
+}))
+
+jest.mock('../../commands/exportPDF', () => ({
+  EXPORT_PDF: 'exportPdf',
+  exportPDF: (startServer: unknown, getBrowserPath: unknown) => (exportPDFMock as any)(startServer, getBrowserPath),
+}))
+
+jest.mock('../../commands/exportHTML', () => ({
+  EXPORT_HTML: 'exportHtml',
+  exportHTML: (logger: unknown, exportAsync: unknown, shouldOpen: unknown) => (exportHTMLMock as any)(logger, exportAsync, shouldOpen),
+}))
+
+jest.mock('../../commands/showSample', () => ({
+  SHOW_SAMPLE: 'showSample',
+  showSample: (...args: unknown[]) => showSampleMock(...args),
+}))
+
+jest.mock('../../commands/newPresentation', () => ({
+  NEW_PRESENTATION: 'newPresentation',
+  createPresentationFromTemplate: (...args: unknown[]) => createPresentationFromTemplateMock(...args),
+}))
+
+jest.mock('../../CompletionItemProvider', () => ({
+  __esModule: true,
+  default: (configDesc: unknown) => (languageCompletionMock as any)(configDesc),
+}))
+
+jest.mock('../../MainController', () => ({
+  __esModule: true,
+  default: function (logger: unknown, context: unknown, configDesc: unknown, config: unknown, editor: unknown) { return (MainControllerMock as any)(logger, context, configDesc, config, editor) },
+}))
+
+jest.mock('../../Configuration', () => ({
+  getConfig: () => (getConfigMock as any)(),
+  getConfigurationDescription: (properties: unknown) => (getConfigurationDescriptionMock as any)(properties),
+}))
+
+import { activate } from '../../extension'
+
+describe('extension activate', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('registers commands, subscriptions and refresh timer', () => {
+    const context = {
+      extension: {
+        packageJSON: {
+          displayName: 'RevealJS',
+          contributes: { configuration: { properties: {} } },
+        },
+      },
+      extensionPath: '/tmp/extension',
+      subscriptions: [],
+    }
+
+    activate(context as any)
+
+    expect(createOutputChannelMock).toHaveBeenCalledWith('RevealJS')
+    expect(MainControllerMock).toHaveBeenCalled()
+    expect(executeCommandMock).toHaveBeenCalledWith('setContext', 'slideExplorerEnabled', true)
+
+    expect(registerCommandMock).toHaveBeenCalledWith('vscode-revealjs.showRevealJS', expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith('showInBrowser', expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith('presenterView', expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith('vscode-revealjs.stopRevealJSServer', expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith('showSample', expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith('newPresentation', expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith('vscode-revealjs.goToSlide', expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith('exportPdf', expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith('exportHtml', expect.any(Function))
+
+    jest.advanceTimersByTime(500)
+    expect(mainControllerInstance.refresh).toHaveBeenCalledWith(0)
+    expect((context as any).subscriptions.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
### Motivation
- Improve coverage and prevent regressions around the PDF export flow and extension activation wiring reported in issue #1430. 
- Verify the integration points that open a browser and register VS Code commands so future refactors remain safe.

### Description
- Add `src/test/UnitTests/exportPDF.jest.ts` to assert `exportPDF` is a no-op when no server URI exists, appends `?print-pdf-now` to the URI, and forwards browser path correctly. 
- Add `src/test/UnitTests/extension.jest.ts` to mock `vscode` and command factories and verify command registration, `setContext` usage, subscription population, and the delayed `main.refresh(0)` call. 
- Use explicit mocks and signatures to avoid TypeScript spread/constructor issues when stubbing `vscode` APIs and the `MainController` factory.

### Testing
- Ran the new tests directly with `npm test -- --runInBand src/test/UnitTests/exportPDF.jest.ts src/test/UnitTests/extension.jest.ts` and both suites passed. 
- Ran the full unit test suite with `npm test -- --runInBand` and all tests passed (all test suites and tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e516ba6960832cb29913c1bfc0619b)