### PR TITLE
test: increase coverage for RevealContext and StatusBarController

### DIFF
--- a/src/test/UnitTests/RevealContext.jest.ts
+++ b/src/test/UnitTests/RevealContext.jest.ts
@@ -1,0 +1,201 @@
+const parseMock = jest.fn()
+const mergeConfigMock = jest.fn((workspace, document) => ({ ...workspace, ...document }))
+const countLinesToSlideMock = jest.fn(() => 5)
+
+const serverStartMock = jest.fn(() => 'http://localhost:1948')
+const serverStopMock = jest.fn()
+
+jest.mock('../../SlideParser', () => ({
+  __esModule: true,
+  default: { parse: (...args: unknown[]) => (parseMock as any)(...args) },
+}))
+
+jest.mock('../../RevealServer', () => ({
+  RevealServer: jest.fn().mockImplementation(() => ({
+    uri: 'http://localhost:1948',
+    start: (...args: unknown[]) => (serverStartMock as any)(...args),
+    stop: (...args: unknown[]) => (serverStopMock as any)(...args),
+    dispose: jest.fn(),
+  })),
+}))
+
+jest.mock('../../Configuration', () => {
+  const real = jest.requireActual('../../Configuration')
+  return {
+    ...real,
+    mergeConfig: (...args: unknown[]) => (mergeConfigMock as any)(...args),
+  }
+})
+
+jest.mock('../../utils', () => ({
+  countLinesToSlide: (...args: unknown[]) => (countLinesToSlideMock as any)(...args),
+}))
+
+jest.mock('vscode', () => {
+  class Position {
+    constructor(public line: number, public character: number) { }
+    translate(deltaLine: number, deltaCharacter = 0) {
+      return new Position(this.line + deltaLine, this.character + deltaCharacter)
+    }
+  }
+
+  class Range {
+    constructor(public start: Position, public end: Position) { }
+  }
+
+  class Selection {
+    constructor(public anchor: Position, public active: Position) { }
+  }
+
+  class EventEmitter<T> {
+    private listener: ((e: T) => void) | undefined
+    get event() {
+      return (cb: (e: T) => void) => {
+        this.listener = cb
+      }
+    }
+    fire(event: T) {
+      this.listener?.(event)
+    }
+    dispose() { }
+  }
+
+  return { Position, Range, Selection, EventEmitter }
+})
+
+import { defaultConfiguration } from '../../Configuration'
+import { LogLevel } from '../../Logger'
+import { RevealContext, RevealContexts } from '../../RevealContext'
+
+describe('RevealContext', () => {
+  const makeEditor = () => ({
+    document: {
+      fileName: '/workspace/slides/main.md',
+      uri: 'doc-uri',
+      getText: jest.fn(() => '# slide'),
+    },
+    revealRange: jest.fn(),
+    selection: undefined,
+  })
+
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    LogLevel: LogLevel.Error,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('computes asset paths and uri helpers', () => {
+    const editor = makeEditor()
+    const context = new RevealContext(editor as any, logger as any, () => ({ ...defaultConfiguration, exportHTMLPath: 'dist' }), '/ext', () => false)
+
+    expect(context.dirname).toBe('/workspace/slides')
+    expect(context.exportPath).toBe('/workspace/slides/dist')
+    expect(context.baseUri).toBe('http://localhost:1948')
+
+    const cssPath = context.resolveLocalAssetPath('styles/custom', true)
+    const absolutePath = context.resolveLocalAssetPath('/tmp/file.css')
+    const externalPath = context.resolveLocalAssetPath('https://example.com/a.css')
+    const dataPath = context.resolveLocalAssetPath('data:text/plain,hello')
+    const queryPath = context.resolveLocalAssetPath('theme.css?v=1#hash')
+
+    expect(cssPath).toBe('/workspace/slides/styles/custom.css')
+    expect(absolutePath).toBe('/tmp/file.css')
+    expect(externalPath).toBeNull()
+    expect(dataPath).toBeNull()
+    expect(queryPath).toBe('/workspace/slides/theme.css')
+
+    context.configuration = {
+      ...defaultConfiguration,
+      customTheme: 'styles/site',
+      css: ['a.css', ' ', 'http://cdn/style.css', 'a.css', 'data:text/plain,hello'],
+    }
+
+    expect(context.getReferencedAssetPaths()).toEqual([
+      '/workspace/slides/init.js',
+      '/workspace/slides/styles/site.css',
+      '/workspace/slides/a.css',
+    ])
+  })
+
+  test('refresh updates configuration, updates position, goToSlide and lifecycle methods', () => {
+    const editor = makeEditor()
+    const context = new RevealContext(editor as any, logger as any, () => ({ ...defaultConfiguration, logLevel: LogLevel.Warning }), '/ext', () => false)
+
+    parseMock
+      .mockReturnValueOnce({
+        frontmatter: { attributes: { logLevel: LogLevel.Debug }, frontmatter: true, bodyBegin: 3 },
+        slides: [{}, {}],
+        parseError: undefined,
+      })
+      .mockReturnValueOnce({
+        frontmatter: { attributes: { logLevel: LogLevel.Debug }, frontmatter: true, bodyBegin: 3 },
+        slides: [{ verticalChildren: ['v'] }],
+        parseError: undefined,
+      })
+      .mockReturnValueOnce({
+        frontmatter: undefined,
+        slides: [{}, { verticalChildren: [1, 2] }],
+        parseError: undefined,
+      })
+
+    const refreshed = context.refresh()
+    expect(refreshed.slides).toHaveLength(2)
+    expect(mergeConfigMock).toHaveBeenCalled()
+    expect(logger.LogLevel).toBe(LogLevel.Debug)
+
+    context.refresh()
+    expect(mergeConfigMock).toHaveBeenCalledTimes(1)
+
+    context.updatePosition({ line: 2, character: 1 } as any)
+
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(12345)
+    expect(context.uriWithPosition).toBe('http://localhost:1948#/1/2/12345')
+    nowSpy.mockRestore()
+
+    context.slides = [{}, {}] as any
+    context.frontmatter = { frontmatter: true, bodyBegin: 4 } as any
+    context.goToSlide(1, 0)
+    expect(countLinesToSlideMock).toHaveBeenCalledWith(context.slides, 1, 0)
+    expect(editor.selection).toBeDefined()
+    expect(editor.revealRange).toHaveBeenCalled()
+
+    expect(context.is({ uri: 'doc-uri' } as any)).toBe(true)
+    expect(context.startServer()).toBe('http://localhost:1948')
+    context.stopServer()
+    expect(serverStopMock).toHaveBeenCalled()
+
+    const onDispose = jest.fn()
+    context.onDidDispose(onDispose)
+    context.dispose()
+    expect(onDispose).toHaveBeenCalled()
+  })
+})
+
+describe('RevealContexts', () => {
+  test('adds, reuses and removes contexts', () => {
+    const logger = { info: jest.fn(), debug: jest.fn(), LogLevel: LogLevel.Error }
+    const contexts = new RevealContexts(logger as any, () => defaultConfiguration, '/ext', () => false, () => {})
+
+    const editor = {
+      document: {
+        fileName: '/workspace/slides/main.md',
+        uri: 'doc-uri',
+        getText: jest.fn(() => ''),
+      },
+      revealRange: jest.fn(),
+    }
+
+    const context = contexts.getOrAdd(editor as any)
+    const sameContext = contexts.getOrAdd(editor as any)
+    expect(context).toBe(sameContext)
+
+    contexts.remove('doc-uri' as any)
+    expect(logger.info).toHaveBeenCalledWith('CONTEXT: doc-uri disposed')
+
+    contexts.remove('unknown-uri' as any)
+  })
+})

--- a/src/test/UnitTests/RevealContext.jest.ts
+++ b/src/test/UnitTests/RevealContext.jest.ts
@@ -12,7 +12,7 @@ jest.mock('../../SlideParser', () => ({
 
 jest.mock('../../RevealServer', () => ({
   RevealServer: jest.fn().mockImplementation(() => ({
-    uri: 'http://localhost:1948',
+    uri: 'http://localhost:1948/',
     start: (...args: unknown[]) => (serverStartMock as any)(...args),
     stop: (...args: unknown[]) => (serverStopMock as any)(...args),
     dispose: jest.fn(),

--- a/src/test/UnitTests/StatusBarController.jest.ts
+++ b/src/test/UnitTests/StatusBarController.jest.ts
@@ -1,0 +1,87 @@
+const createdItems: any[] = []
+
+jest.mock('vscode', () => ({
+  StatusBarAlignment: { Right: 2 },
+  window: {
+    createStatusBarItem: jest.fn(() => {
+      const item = {
+        text: '',
+        color: undefined,
+        command: undefined,
+        show: jest.fn(),
+        hide: jest.fn(),
+        dispose: jest.fn(),
+      }
+      createdItems.push(item)
+      return item
+    }),
+  },
+}))
+
+import { StatusBarController } from '../../StatusBarController'
+import { SHOW_REVEALJS } from '../../commands/showRevealJS'
+import { SHOW_REVEALJS_IN_BROWSER } from '../../commands/showRevealJSInBrowser'
+import { STOP_REVEALJS_SERVER } from '../../commands/stopRevealJSServer'
+
+describe('StatusBarController', () => {
+  beforeEach(() => {
+    createdItems.length = 0
+  })
+
+  test('constructor configures status bar items', () => {
+    new StatusBarController()
+
+    const [addressItem, stopItem, countItem] = createdItems
+    expect(addressItem.command).toBe(SHOW_REVEALJS_IN_BROWSER)
+    expect(stopItem.command).toBe(STOP_REVEALJS_SERVER)
+    expect(stopItem.text).toBe('$(primitive-square)')
+    expect(stopItem.color).toBe('red')
+    expect(countItem.command).toBe(SHOW_REVEALJS)
+    expect(addressItem.hide).toHaveBeenCalled()
+    expect(stopItem.hide).toHaveBeenCalled()
+    expect(countItem.hide).toHaveBeenCalled()
+  })
+
+  test('updateServerInfo toggles visibility and text', () => {
+    const controller = new StatusBarController()
+    const [addressItem, stopItem] = createdItems
+
+    controller.updateServerInfo('http://localhost:1948')
+    expect(addressItem.text).toBe('$(server) http://localhost:1948')
+    expect(addressItem.show).toHaveBeenCalledTimes(1)
+    expect(stopItem.show).toHaveBeenCalledTimes(1)
+
+    controller.updateServerInfo('http://localhost:1948')
+    expect(addressItem.text).toBe('')
+    expect(addressItem.hide).toHaveBeenCalledTimes(2)
+    expect(stopItem.hide).toHaveBeenCalledTimes(2)
+
+    controller.updateServerInfo(null)
+    expect(addressItem.hide).toHaveBeenCalledTimes(3)
+    expect(stopItem.hide).toHaveBeenCalledTimes(3)
+  })
+
+  test('updateCount updates singular/plural and hides for invalid counts', () => {
+    const controller = new StatusBarController()
+    const countItem = createdItems[2]
+
+    controller.updateCount(1)
+    expect(countItem.text).toBe('$(note) 1 slide')
+    expect(countItem.show).toHaveBeenCalledTimes(1)
+
+    controller.updateCount(2)
+    expect(countItem.text).toBe('$(note) 2 slides')
+    expect(countItem.show).toHaveBeenCalledTimes(2)
+
+    controller.updateCount(2)
+    expect(countItem.show).toHaveBeenCalledTimes(2)
+    expect(countItem.hide).toHaveBeenCalledTimes(1)
+
+    controller.updateCount(0)
+    expect(countItem.text).toBe('')
+    expect(countItem.hide).toHaveBeenCalledTimes(2)
+
+    controller.updateCount(null)
+    expect(countItem.hide).toHaveBeenCalledTimes(3)
+  })
+})


### PR DESCRIPTION
### Motivation

- Add focused unit tests to exercise logic in `RevealContext`/`RevealContexts` and `StatusBarController` to raise coverage and catch regressions around path resolution, server state and status-bar behavior.

### Description

- Add `src/test/UnitTests/RevealContext.jest.ts` with mocks for `SlideParser`, `RevealServer`, `mergeConfig` and `countLinesToSlide` and tests covering asset path resolution, referenced assets discovery, export path computation, `uriWithPosition`, `refresh` behavior, `updatePosition`, `goToSlide`, server lifecycle and disposal events.
- Add `src/test/UnitTests/StatusBarController.jest.ts` which mocks VS Code `window.createStatusBarItem` and tests constructor wiring, `updateServerInfo` visibility toggling and `updateCount` singular/plural rendering and hide behavior.
- Tests isolate module behavior using lightweight `vscode` and dependency mocks so CI-friendly unit tests exercise branches in the target files.

### Testing

- Ran unit tests with `npm test -- src/test/UnitTests/RevealContext.jest.ts src/test/UnitTests/StatusBarController.jest.ts` and all tests passed (6 passed, 0 failed).
- Collected coverage with `npm run coverage -- src/test/UnitTests/RevealContext.jest.ts src/test/UnitTests/StatusBarController.jest.ts --collectCoverageFrom=src/RevealContext.ts --collectCoverageFrom=src/StatusBarController.ts` and observed coverage results: `RevealContext.ts` lines 100%, `StatusBarController.ts` lines 97.72%.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53682ddfc832caca5bbdf9ce8b5fe)