### PR TITLE
ci: ensure SonarCloud PR analysis uses coverage and exclude test files from coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -26,6 +28,12 @@ jobs:
 
       - name: test 
         run: npm run coverage
+
+      - name: Verify SonarCloud coverage inputs
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          test -f coverage/lcov.info
+          test -f test-report.xml
       
       - name: SonarCloud Scan
         if: matrix.os == 'ubuntu-latest'
@@ -41,4 +49,3 @@ jobs:
 
       - name: Package extension smoke test
         run: vsce package
-

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.projectKey=evilz_vscode-reveal
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=./src
-sonar.tests=./src/test
+sonar.tests=./src
 
 sonar.testExecutionReportPaths=test-report.xml
 sonar.cs.opencover.reportsPaths=./Fun2C.Tests/coverage.opencover.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,10 +4,11 @@ sonar.projectKey=evilz_vscode-reveal
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=./src
+sonar.tests=./src/test
 
 sonar.testExecutionReportPaths=test-report.xml
 sonar.cs.opencover.reportsPaths=./Fun2C.Tests/coverage.opencover.xml
 
 sonar.test.inclusions= **/*.jest.ts
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
-sonar.testExecutionReportPaths=test-report.xml
+sonar.coverage.exclusions=src/**/*.jest.ts,src/test/**/*


### PR DESCRIPTION
### Motivation
- Make SonarCloud PR analysis reliably receive test and coverage artifacts so PRs include accurate coverage data.
- Prevent test files from being counted in production coverage metrics so reported coverage reflects source code only.

### Description
- Added `sonar.tests=./src/test` to `sonar-project.properties` to mark the test root for SonarCloud.
- Added `sonar.coverage.exclusions=src/**/*.jest.ts,src/test/**/*` to `sonar-project.properties` to exclude Jest test files and test directory from coverage.
- Removed a duplicate `sonar.testExecutionReportPaths` entry and kept the TypeScript LCOV path in `sonar-project.properties`.
- Updated `.github/workflows/build.yml` to use a full checkout (`fetch-depth: 0`) and added an Ubuntu-only verification step that checks `coverage/lcov.info` and `test-report.xml` exist before running the SonarCloud scan.

### Testing
- Ran `npm run coverage` which executed the test suite and generated coverage artifacts successfully.
- Verified artifacts exist with `test -f coverage/lcov.info && test -f test-report.xml` which returned success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68e954dd4832cbcfe1c6293035fd5)