### PR TITLE
Support markdown-authored reveal.js fragments: docs, snippets, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Since Reveal.js use marked to parse the markdown string you can use this in your
 - GitHub flavored markdown.
 - GFM tables
 
+Fragments can be authored directly in markdown with attributes (no raw HTML needed):
+
+```md
+- First point {.fragment}
+- Then emphasize this {.fragment .highlight-red}
+- Finally this one {.fragment data-fragment-index="2"}
+
+Paragraph shown later {.fragment .fade-up}
+```
+
 If you need a sample file you can get it here:
 https://raw.githubusercontent.com/evilz/vscode-reveal/master/sample.md
 

--- a/docs/markdown/extended-syntax.md
+++ b/docs/markdown/extended-syntax.md
@@ -26,6 +26,16 @@ paragraph {data-toggle=modal}
 
 ![attributes](../assets/images/attributes.png)
 
+## Fragments in markdown (without HTML)
+
+```markdown
+- First point {.fragment}
+- Grow {.fragment .grow}
+- Highlight {.fragment .highlight-red data-fragment-index="2"}
+
+Reveal this paragraph later {.fragment .fade-up}
+```
+
 ## Abbreviation
 
 ```markdown
@@ -176,4 +186,3 @@ content
 ```
 
 ![Iframe](../assets/images/iframe.png)
-

--- a/samples/markdown-syntax.md
+++ b/samples/markdown-syntax.md
@@ -144,3 +144,13 @@ First Header | Second Header
 ------------ | -------------
 Content from cell 1 | Content from cell 2
 Content in the first column | Content in the second column
+
+---
+
+# Fragments
+
+- First appears {.fragment}
+- Then this grows {.fragment .grow}
+- Then this highlights {.fragment .highlight-blue data-fragment-index="2"}
+
+This paragraph fades up later {.fragment .fade-up}

--- a/snippets.json
+++ b/snippets.json
@@ -44,7 +44,7 @@
     "Fragment list item with effect": {
         "prefix": "-frx",
         "body": [
-            "- ${1:text} {.fragment .${2|grow,shrink,fade-out,fade-right,fade-up,fade-down,fade-left,fade-in-then-out,fade-in-then-semi-out,highlight-red,highlight-green,highlight-blue,current-visible|}}"
+            "- ${1:text} {.fragment .${2|grow,shrink,fade-out,fade-right,fade-up,fade-down,fade-left,fade-in-then-out,fade-in-then-semi-out,highlight-red,highlight-green,highlight-blue,highlight-current-red,highlight-current-green,highlight-current-blue,current-visible|}}"
         ],
         "description": "Add fragment list item with reveal.js effect class"
     },
@@ -58,7 +58,7 @@
     "Fragment paragraph with effect": {
         "prefix": "fr-px",
         "body": [
-            "${1:text} {.fragment .${2|grow,shrink,fade-out,fade-right,fade-up,fade-down,fade-left,fade-in-then-out,fade-in-then-semi-out,highlight-red,highlight-green,highlight-blue,current-visible|}}"
+            "${1:text} {.fragment .${2|grow,shrink,fade-out,fade-right,fade-up,fade-down,fade-left,fade-in-then-out,fade-in-then-semi-out,highlight-red,highlight-green,highlight-blue,highlight-current-red,highlight-current-green,highlight-current-blue,current-visible|}}"
         ],
         "description": "Add fragment paragraph with reveal.js effect class"
     },

--- a/snippets.json
+++ b/snippets.json
@@ -33,5 +33,40 @@
             "- ${1:text} {.fragment}"
         ],
         "description": "Add fragment list item"
+    },
+    "Fragment paragraph": {
+        "prefix": "fr-p",
+        "body": [
+            "${1:text} {.fragment}"
+        ],
+        "description": "Add fragment paragraph"
+    },
+    "Fragment list item with effect": {
+        "prefix": "-frx",
+        "body": [
+            "- ${1:text} {.fragment .${2|grow,shrink,fade-out,fade-right,fade-up,fade-down,fade-left,fade-in-then-out,fade-in-then-semi-out,highlight-red,highlight-green,highlight-blue,current-visible|}}"
+        ],
+        "description": "Add fragment list item with reveal.js effect class"
+    },
+    "Fragment list item with index": {
+        "prefix": "-fri",
+        "body": [
+            "- ${1:text} {.fragment data-fragment-index=\"${2:0}\"}"
+        ],
+        "description": "Add fragment list item with data-fragment-index"
+    },
+    "Fragment paragraph with effect": {
+        "prefix": "fr-px",
+        "body": [
+            "${1:text} {.fragment .${2|grow,shrink,fade-out,fade-right,fade-up,fade-down,fade-left,fade-in-then-out,fade-in-then-semi-out,highlight-red,highlight-green,highlight-blue,current-visible|}}"
+        ],
+        "description": "Add fragment paragraph with reveal.js effect class"
+    },
+    "Fragment paragraph with index": {
+        "prefix": "fr-pi",
+        "body": [
+            "${1:text} {.fragment data-fragment-index=\"${2:0}\"}"
+        ],
+        "description": "Add fragment paragraph with data-fragment-index"
     }
 }

--- a/src/test/UnitTests/DependenciesUpdate.jest.ts
+++ b/src/test/UnitTests/DependenciesUpdate.jest.ts
@@ -149,7 +149,9 @@ test('Markdown-it attributes can be used for reveal.js fragments', () => {
   const listItemResult = md.render('- Step one {.fragment .fade-up data-fragment-index="2"}');
   expect(listItemResult).toContain('class="fragment fade-up"');
   expect(listItemResult).toContain('data-fragment-index="2"');
+  expect(listItemResult).not.toContain('{.fragment');
 
   const paragraphResult = md.render('Reveal later {.fragment}');
   expect(paragraphResult).toContain('<p class="fragment">Reveal later</p>');
+  expect(paragraphResult).not.toContain('{.fragment');
 });

--- a/src/test/UnitTests/DependenciesUpdate.jest.ts
+++ b/src/test/UnitTests/DependenciesUpdate.jest.ts
@@ -139,3 +139,17 @@ test('Markdown-it plugins should work together', () => {
   const result4 = md.render('++inserted++');
   expect(result4).toContain('<ins>inserted</ins>');
 });
+
+test('Markdown-it attributes can be used for reveal.js fragments', () => {
+  const MarkdownIt = require('markdown-it');
+  const markdownItAttrs = require('markdown-it-attrs');
+
+  const md = new MarkdownIt().use(markdownItAttrs);
+
+  const listItemResult = md.render('- Step one {.fragment .fade-up data-fragment-index="2"}');
+  expect(listItemResult).toContain('class="fragment fade-up"');
+  expect(listItemResult).toContain('data-fragment-index="2"');
+
+  const paragraphResult = md.render('Reveal later {.fragment}');
+  expect(paragraphResult).toContain('<p class="fragment">Reveal later</p>');
+});


### PR DESCRIPTION
### Motivation

- Document and demonstrate how to author reveal.js fragments directly in markdown using attributes without raw HTML.

### Description

- Add fragment usage examples to `README.md`, `docs/markdown/extended-syntax.md`, and `samples/markdown-syntax.md` to show list-item and paragraph fragments with effects and `data-fragment-index`.
- Add multiple editor snippets in `snippets.json` for fragment list items and paragraphs, including variants with effect classes and `data-fragment-index`.
- Extend unit tests in `src/test/UnitTests/DependenciesUpdate.jest.ts` to include `Markdown-it attributes can be used for reveal.js fragments` which verifies `markdown-it-attrs` renders `class="fragment ..."` and `data-fragment-index` attributes.

### Testing

- Ran unit tests with `npm test` (Jest) and the test suite completed successfully.  
- Added and executed the `Markdown-it attributes can be used for reveal.js fragments` test which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d8a89aa8832c9e0a19703ff121ec)