### PR TITLE
fix: log reveal server port on startup

### DIFF
--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -32,7 +32,7 @@ export class RevealServer extends Disposable {
         this.server = this.app.listen(0)
         const uri = this.uri
         const port = this.port
-        this.context.logger.info(`SERVER started at ${uri}${port === null ? '' : ` (port ${port})`}`)
+        this.context.logger.info(`SERVER started${uri ? ` at ${uri}` : ''}${port === null ? '' : ` (port ${port})`}`)
       }
     } catch (err) {
       const error = new Error(`Cannot start server: ${err}`)

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -30,7 +30,9 @@ export class RevealServer extends Disposable {
     try {
       if (!this.isListening) {
         this.server = this.app.listen(0)
-        this.context.logger.info(`SERVER started`)
+        const uri = this.uri
+        const port = this.port
+        this.context.logger.info(`SERVER started at ${uri}${port === null ? '' : ` (port ${port})`}`)
       }
     } catch (err) {
       const error = new Error(`Cannot start server: ${err}`)
@@ -53,20 +55,33 @@ export class RevealServer extends Disposable {
     }
   }
 
+  /** The current port for this server, null if not listening */
+  public get port() {
+    if (!this.isListening || this.server === null) {
+      return null
+    }
+
+    const addr = this.server.address()
+    if (typeof addr === 'string' || addr === null) {
+      return null
+    }
+
+    return addr.port
+  }
+
   /** Current uri for this server, empty is not listening */
   public get uri() {
     if (!this.isListening || this.server === null) {
       return ''
     }
 
-    const addr = this.server.address()
-    if (typeof addr === 'string') {
-      return addr
+    const port = this.port
+    if (port === null) {
+      const addr = this.server.address()
+      return typeof addr === 'string' ? addr : ''
     }
-    if (addr === null) {
-      return ''
-    }
-    return `http://${this.host}:${addr.port}/`
+
+    return `http://${this.host}:${port}/`
   }
 
   /** The function configures the express app to serve the presentation */

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -51,10 +51,35 @@ describe('RevealServer', () => {
     expect(server.isListening).toBeTruthy()
     expect(uri).toMatch(/^http:\/\/localhost:\d+\/$/)
     expect(uri).toBe(server.uri)
+    expect(server.port).toEqual(expect.any(Number))
 
     server.stop()
     expect(server.isListening).toBeFalsy()
     expect(server.uri).toBe('')
+    expect(server.port).toBeNull()
+
+    server.dispose()
+    context.dispose()
+  })
+
+  test('start logs the concrete server uri and port', () => {
+    const messages: string[] = []
+    const logger = new Logger((message) => messages.push(message), LogLevel.Info)
+    const context = new RevealContext(
+      { document: { fileName: path.join(os.tmpdir(), 'deck.md') } } as TextEditor,
+      logger,
+      () => defaultConfiguration,
+      process.cwd(),
+      () => false,
+      () => undefined,
+    )
+    const server = new RevealServer(context)
+
+    const uri = server.start()
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toContain(`SERVER started at ${uri}`)
+    expect(messages[0]).toContain(`(port ${server.port})`)
 
     server.dispose()
     context.dispose()


### PR DESCRIPTION
## Summary
- log the full local reveal server URI when the preview server starts
- include the concrete port number in the output channel to make remote port forwarding easier
- add unit coverage for the reported URI/port and the new port accessor

## Testing
- npm test -- --runInBand
- npm run build

Fixes #1374