### PR TITLE
Improve workspace-aware path resolution for local assets and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ customTheme : "my-theme"
 
 Note that you can use both theme and custom theme at the same time. Your custom theme will be loaded after to override default reveal.js theme.
 
+Path resolution rules for local assets and export:
+- `customTheme`, `css`, and `init.js` are resolved from the markdown document folder when the document is saved (`file:` and remote `vscode-remote:` documents).
+- For unsaved `untitled:` documents, relative paths resolve from the matching workspace folder (or the first workspace folder if no direct match exists).
+- For virtual/non-file documents without a workspace folder, relative local asset paths are ignored gracefully (remote URLs still work).
+- `revealjs.exportHTMLPath` keeps absolute paths as-is; relative export paths resolve from the same base folder rules above.
+- If a markdown file is outside the workspace, its own folder remains the resolution base to avoid cross-workspace surprises.
+
 
 
 ## <a id="highlight"></a> Highlight Theme

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -1,7 +1,7 @@
 import { FrontMatterResult } from 'front-matter'
 import path from 'path'
 import { isDeepStrictEqual } from 'util'
-import { EventEmitter, Position, Range, Selection, TextDocument, TextEditor, Uri } from 'vscode'
+import { EventEmitter, Position, Range, Selection, TextDocument, TextEditor, Uri, workspace } from 'vscode'
 import { Configuration, mergeConfig } from './Configuration'
 import { Disposable } from './dispose'
 import { ISlide } from './ISlide'
@@ -47,8 +47,14 @@ export class RevealContext extends Disposable {
     return this.editor.document.getText(range)
   }
 
-  public get dirname() {
-    return path.dirname(this.editor.document.fileName)
+  public get dirname(): string | null {
+    const uri = this.editor.document.uri
+    if ((uri.scheme === 'file' || uri.scheme === 'vscode-remote') && this.editor.document.fileName) {
+      return path.dirname(this.editor.document.fileName)
+    }
+
+    const workspaceFolder = workspace.getWorkspaceFolder(uri) ?? workspace.workspaceFolders?.[0]
+    return workspaceFolder?.uri.fsPath ?? null
   }
 
   get uriWithPosition() {
@@ -63,7 +69,7 @@ export class RevealContext extends Disposable {
   public get exportPath(): string {
     return path.isAbsolute(this.configuration.exportHTMLPath)
       ? this.configuration.exportHTMLPath
-      : path.join(this.dirname, this.configuration.exportHTMLPath)
+      : path.resolve(this.dirname ?? process.cwd(), this.configuration.exportHTMLPath)
   }
 
   public resolveLocalAssetPath(assetPath: string | null | undefined, appendCssIfMissing = false): string | null {
@@ -74,7 +80,13 @@ export class RevealContext extends Disposable {
     if (/^(https?:)?\/\//i.test(trimmed) || /^data:/i.test(trimmed)) return null
 
     const [cleanedPath] = trimmed.split(/[?#]/)
-    const resolvedPath = path.isAbsolute(cleanedPath) ? cleanedPath : path.resolve(this.dirname, cleanedPath)
+    const baseDir = this.dirname
+    const resolvedPath = path.isAbsolute(cleanedPath)
+      ? cleanedPath
+      : baseDir
+        ? path.resolve(baseDir, cleanedPath)
+        : null
+    if (!resolvedPath) return null
     if (appendCssIfMissing && !path.extname(resolvedPath)) {
       return `${resolvedPath}.css`
     }
@@ -83,7 +95,10 @@ export class RevealContext extends Disposable {
 
   public getReferencedAssetPaths(): string[] {
     const paths = new Set<string>()
-    paths.add(path.join(this.dirname, 'init.js'))
+    const baseDir = this.dirname
+    if (baseDir) {
+      paths.add(path.join(baseDir, 'init.js'))
+    }
 
     const customThemePath = this.resolveLocalAssetPath(this.configuration.customTheme, true)
     if (customThemePath) {

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -48,12 +48,16 @@ export class RevealContext extends Disposable {
   }
 
   public get dirname(): string | null {
-    const uri = this.editor.document.uri
-    if ((uri.scheme === 'file' || uri.scheme === 'vscode-remote') && this.editor.document.fileName) {
+    const uri = this.editor.document.uri as Uri | undefined
+    const uriScheme = uri && typeof uri === 'object' ? uri.scheme : undefined
+
+    if ((uriScheme === 'file' || uriScheme === 'vscode-remote' || !uriScheme) && this.editor.document.fileName) {
       return path.dirname(this.editor.document.fileName)
     }
 
-    const workspaceFolder = workspace.getWorkspaceFolder(uri) ?? workspace.workspaceFolders?.[0]
+    const workspaceFolder = uri && typeof uri === 'object'
+      ? workspace.getWorkspaceFolder(uri) ?? workspace.workspaceFolders?.[0]
+      : workspace.workspaceFolders?.[0]
     return workspaceFolder?.uri.fsPath ?? null
   }
 

--- a/src/test/UnitTests/RevealContext.jest.ts
+++ b/src/test/UnitTests/RevealContext.jest.ts
@@ -1,22 +1,26 @@
 import * as path from 'path'
 
+const serverUri = 'http://localhost:1948/'
 const parseMock = jest.fn()
 const mergeConfigMock = jest.fn((workspace, document) => ({ ...workspace, ...document }))
-const countLinesToSlideMock = jest.fn(() => 5)
+const countLinesToSlideMock = jest.fn((...args: unknown[]) => {
+  void args
+  return 5
+})
 
-const serverStartMock = jest.fn(() => 'http://localhost:1948/')
+const serverStartMock = jest.fn(() => serverUri)
 const serverStopMock = jest.fn()
 
 jest.mock('../../SlideParser', () => ({
   __esModule: true,
-  default: { parse: (...args: unknown[]) => (parseMock as any)(...args) },
+  default: { parse: (...args: unknown[]) => parseMock(...args) },
 }))
 
 jest.mock('../../RevealServer', () => ({
   RevealServer: jest.fn().mockImplementation(() => ({
-    uri: 'http://localhost:1948/',
-    start: (...args: unknown[]) => (serverStartMock as any)(...args),
-    stop: (...args: unknown[]) => (serverStopMock as any)(...args),
+    uri: serverUri,
+    start: () => serverStartMock(),
+    stop: () => serverStopMock(),
     onDidStart: jest.fn(),
     onDidStop: jest.fn(),
     dispose: jest.fn(),
@@ -27,12 +31,12 @@ jest.mock('../../Configuration', () => {
   const real = jest.requireActual('../../Configuration')
   return {
     ...real,
-    mergeConfig: (...args: unknown[]) => (mergeConfigMock as any)(...args),
+    mergeConfig: (workspaceConfig: unknown, documentConfig: unknown) => mergeConfigMock(workspaceConfig, documentConfig),
   }
 })
 
 jest.mock('../../utils', () => ({
-  countLinesToSlide: (...args: unknown[]) => (countLinesToSlideMock as any)(...args),
+  countLinesToSlide: (slides: unknown, horizontal: unknown, vertical: unknown) => countLinesToSlideMock(slides, horizontal, vertical),
 }))
 
 jest.mock('vscode', () => {
@@ -81,10 +85,18 @@ jest.mock('vscode', () => {
   return { Position, Range, Selection, EventEmitter, workspace }
 })
 
-import { defaultConfiguration } from '../../Configuration'
-import { LogLevel } from '../../Logger'
+import type { FrontMatterResult } from 'front-matter'
+import { Configuration, defaultConfiguration } from '../../Configuration'
+import Logger, { LogLevel } from '../../Logger'
+import { ISlide } from '../../ISlide'
 import { RevealContext, RevealContexts } from '../../RevealContext'
-import { workspace } from 'vscode'
+import { Position, TextDocument, TextEditor, Uri, workspace } from 'vscode'
+
+type MutableWorkspaceMock = {
+  workspaceFolders: Array<{ uri: { fsPath: string } }> | undefined
+  getWorkspaceFolder: jest.Mock
+}
+const workspaceMock = workspace as unknown as MutableWorkspaceMock
 
 describe('RevealContext', () => {
   const makeEditor = () => ({
@@ -105,15 +117,15 @@ describe('RevealContext', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    ;(workspace as any).workspaceFolders = undefined
-    ;(workspace.getWorkspaceFolder as jest.Mock).mockReturnValue(undefined)
+    workspaceMock.workspaceFolders = undefined
+    workspaceMock.getWorkspaceFolder.mockReturnValue(undefined)
   })
 
   test('computes asset paths and uri helpers', () => {
     const editor = makeEditor()
     const context = new RevealContext(
-      editor as any,
-      logger as any,
+      editor as unknown as TextEditor,
+      logger as unknown as Logger,
       () => ({ ...defaultConfiguration, exportHTMLPath: 'dist' }),
       '/ext',
       () => false,
@@ -122,7 +134,7 @@ describe('RevealContext', () => {
 
     expect(context.dirname).toBe(slidesDir)
     expect(context.exportPath).toBe(path.resolve(slidesDir, 'dist'))
-    expect(context.baseUri).toBe('http://localhost:1948/')
+    expect(context.baseUri).toBe(serverUri)
 
     const cssPath = context.resolveLocalAssetPath('styles/custom', true)
     const absoluteCssPath = path.join(path.sep, 'tmp', 'file.css')
@@ -148,7 +160,7 @@ describe('RevealContext', () => {
 
   test('uses workspace folder as base dir for untitled documents and tolerates unresolved virtual documents', () => {
     const workspaceDir = path.join(path.sep, 'workspace', 'project-a')
-    ;(workspace as any).workspaceFolders = [{ uri: { fsPath: workspaceDir } }]
+    workspaceMock.workspaceFolders = [{ uri: { fsPath: workspaceDir } }]
 
     const untitledEditor = {
       document: {
@@ -160,8 +172,8 @@ describe('RevealContext', () => {
       selection: undefined,
     }
     const untitledContext = new RevealContext(
-      untitledEditor as any,
-      logger as any,
+      untitledEditor as unknown as TextEditor,
+      logger as unknown as Logger,
       () => ({ ...defaultConfiguration, exportHTMLPath: 'dist' }),
       '/ext',
       () => false
@@ -182,8 +194,8 @@ describe('RevealContext', () => {
       selection: undefined,
     }
     const virtualContext = new RevealContext(
-      virtualEditor as any,
-      logger as any,
+      virtualEditor as unknown as TextEditor,
+      logger as unknown as Logger,
       () => ({ ...defaultConfiguration, exportHTMLPath: 'dist' }),
       '/ext',
       () => false
@@ -202,8 +214,8 @@ describe('RevealContext', () => {
   test('refresh updates configuration, updates position, goToSlide and lifecycle methods', () => {
     const editor = makeEditor()
     const context = new RevealContext(
-      editor as any,
-      logger as any,
+      editor as unknown as TextEditor,
+      logger as unknown as Logger,
       () => ({ ...defaultConfiguration, logLevel: LogLevel.Warning }),
       '/ext',
       () => false,
@@ -234,21 +246,21 @@ describe('RevealContext', () => {
     context.refresh()
     expect(mergeConfigMock).toHaveBeenCalledTimes(1)
 
-    context.updatePosition({ line: 2, character: 1 } as any)
+    context.updatePosition(new Position(2, 1))
 
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(12345)
-    expect(context.uriWithPosition).toBe('http://localhost:1948/#/1/2/12345')
+    expect(context.uriWithPosition).toBe(`${serverUri}#/1/2/12345`)
     nowSpy.mockRestore()
 
-    context.slides = [{}, {}] as any
-    context.frontmatter = { frontmatter: true, bodyBegin: 4 } as any
+    context.slides = [{}, {}] as unknown as ISlide[]
+    context.frontmatter = { frontmatter: true, bodyBegin: 4 } as unknown as FrontMatterResult<Configuration>
     context.goToSlide(1, 0)
     expect(countLinesToSlideMock).toHaveBeenCalledWith(context.slides, 1, 0)
     expect(editor.selection).toBeDefined()
     expect(editor.revealRange).toHaveBeenCalled()
 
-    expect(context.is({ uri: editor.document.uri } as any)).toBe(true)
-    expect(context.startServer()).toBe('http://localhost:1948/')
+    expect(context.is({ uri: editor.document.uri } as unknown as TextDocument)).toBe(true)
+    expect(context.startServer()).toBe(serverUri)
     context.stopServer()
     expect(serverStopMock).toHaveBeenCalled()
 
@@ -263,7 +275,7 @@ describe('RevealContexts', () => {
   test('adds, reuses and removes contexts', () => {
     const logger = { info: jest.fn(), debug: jest.fn(), LogLevel: LogLevel.Error }
     const contexts = new RevealContexts(
-      logger as any,
+      logger as unknown as Logger,
       () => defaultConfiguration,
       '/ext',
       () => false,
@@ -281,13 +293,13 @@ describe('RevealContexts', () => {
       revealRange: jest.fn(),
     }
 
-    const context = contexts.getOrAdd(editor as any)
-    const sameContext = contexts.getOrAdd(editor as any)
+    const context = contexts.getOrAdd(editor as unknown as TextEditor)
+    const sameContext = contexts.getOrAdd(editor as unknown as TextEditor)
     expect(context).toBe(sameContext)
 
-    contexts.remove(editor.document.uri as any)
+    contexts.remove(editor.document.uri as unknown as Uri)
     expect(logger.info).toHaveBeenCalledWith('CONTEXT: doc-uri disposed')
 
-    contexts.remove('unknown-uri' as any)
+    contexts.remove('unknown-uri' as unknown as Uri)
   })
 })

--- a/src/test/UnitTests/RevealContext.jest.ts
+++ b/src/test/UnitTests/RevealContext.jest.ts
@@ -34,6 +34,11 @@ jest.mock('../../utils', () => ({
 }))
 
 jest.mock('vscode', () => {
+  const workspace = {
+    workspaceFolders: undefined as unknown,
+    getWorkspaceFolder: jest.fn(),
+  }
+
   class Position {
     constructor(public line: number, public character: number) { }
     translate(deltaLine: number, deltaCharacter = 0) {
@@ -62,18 +67,19 @@ jest.mock('vscode', () => {
     dispose() { }
   }
 
-  return { Position, Range, Selection, EventEmitter }
+  return { Position, Range, Selection, EventEmitter, workspace }
 })
 
 import { defaultConfiguration } from '../../Configuration'
 import { LogLevel } from '../../Logger'
 import { RevealContext, RevealContexts } from '../../RevealContext'
+import { workspace } from 'vscode'
 
 describe('RevealContext', () => {
   const makeEditor = () => ({
     document: {
       fileName: '/workspace/slides/main.md',
-      uri: 'doc-uri',
+      uri: { scheme: 'file', toString: () => 'doc-uri' },
       getText: jest.fn(() => '# slide'),
     },
     revealRange: jest.fn(),
@@ -88,6 +94,8 @@ describe('RevealContext', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    ;(workspace as any).workspaceFolders = undefined
+    ;(workspace.getWorkspaceFolder as jest.Mock).mockReturnValue(undefined)
   })
 
   test('computes asset paths and uri helpers', () => {
@@ -123,6 +131,55 @@ describe('RevealContext', () => {
       path.resolve(slidesDir, 'styles', 'site.css'),
       path.resolve(slidesDir, 'a.css'),
     ])
+  })
+
+  test('uses workspace folder as base dir for untitled documents and tolerates unresolved virtual documents', () => {
+    const workspaceDir = path.join(path.sep, 'workspace', 'project-a')
+    ;(workspace as any).workspaceFolders = [{ uri: { fsPath: workspaceDir } }]
+
+    const untitledEditor = {
+      document: {
+        fileName: 'Untitled-1',
+        uri: { scheme: 'untitled' },
+        getText: jest.fn(() => '# slide'),
+      },
+      revealRange: jest.fn(),
+      selection: undefined,
+    }
+    const untitledContext = new RevealContext(
+      untitledEditor as any,
+      logger as any,
+      () => ({ ...defaultConfiguration, exportHTMLPath: 'dist' }),
+      '/ext',
+      () => false
+    )
+
+    expect(untitledContext.dirname).toBe(workspaceDir)
+    expect(untitledContext.exportPath).toBe(path.resolve(workspaceDir, 'dist'))
+    expect(untitledContext.resolveLocalAssetPath('styles/site.css')).toBe(path.resolve(workspaceDir, 'styles', 'site.css'))
+    expect(untitledContext.getReferencedAssetPaths()).toContain(path.join(workspaceDir, 'init.js'))
+
+    ;(workspace as any).workspaceFolders = undefined
+    const virtualEditor = {
+      document: {
+        fileName: 'generated',
+        uri: { scheme: 'git' },
+        getText: jest.fn(() => '# slide'),
+      },
+      revealRange: jest.fn(),
+      selection: undefined,
+    }
+    const virtualContext = new RevealContext(
+      virtualEditor as any,
+      logger as any,
+      () => ({ ...defaultConfiguration, exportHTMLPath: 'dist' }),
+      '/ext',
+      () => false
+    )
+
+    expect(virtualContext.dirname).toBeNull()
+    expect(virtualContext.resolveLocalAssetPath('styles/site.css')).toBeNull()
+    expect(virtualContext.getReferencedAssetPaths()).toEqual([])
   })
 
   test('refresh updates configuration, updates position, goToSlide and lifecycle methods', () => {
@@ -167,7 +224,7 @@ describe('RevealContext', () => {
     expect(editor.selection).toBeDefined()
     expect(editor.revealRange).toHaveBeenCalled()
 
-    expect(context.is({ uri: 'doc-uri' } as any)).toBe(true)
+    expect(context.is({ uri: editor.document.uri } as any)).toBe(true)
     expect(context.startServer()).toBe('http://localhost:1948/')
     context.stopServer()
     expect(serverStopMock).toHaveBeenCalled()
@@ -187,7 +244,7 @@ describe('RevealContexts', () => {
     const editor = {
       document: {
         fileName: '/workspace/slides/main.md',
-        uri: 'doc-uri',
+        uri: { scheme: 'file', toString: () => 'doc-uri' },
         getText: jest.fn(() => ''),
       },
       revealRange: jest.fn(),
@@ -197,7 +254,7 @@ describe('RevealContexts', () => {
     const sameContext = contexts.getOrAdd(editor as any)
     expect(context).toBe(sameContext)
 
-    contexts.remove('doc-uri' as any)
+    contexts.remove(editor.document.uri as any)
     expect(logger.info).toHaveBeenCalledWith('CONTEXT: doc-uri disposed')
 
     contexts.remove('unknown-uri' as any)


### PR DESCRIPTION
### Motivation
- Ensure predictable resolution for `customTheme`, `css`, `init.js`, and `revealjs.exportHTMLPath` across multi-root, remote, untitled and virtual documents. 
- Avoid surprising behavior when a markdown file lives outside the workspace and gracefully handle unsaved/virtual documents. 
- Add tests to lock in the chosen path semantics and document the rules for users.

### Description
- Update `RevealContext.dirname` to return the markdown file folder for `file:` and `vscode-remote:` URIs, fall back to `workspace.getWorkspaceFolder(uri)` or `workspace.workspaceFolders?.[0]` for `untitled:` editors, and return `null` for virtual/non-file docs. 
- Make `exportPath` resolve relative paths via `path.resolve(this.dirname ?? process.cwd(), ...)` while leaving absolute export paths unchanged. 
- Change `resolveLocalAssetPath` to return `null` for relative assets when no base directory is available, and only add `init.js` to referenced assets when a base dir exists. 
- Add unit tests in `src/test/UnitTests/RevealContext.jest.ts` covering saved file behavior, untitled workspace fallback, and virtual-document graceful handling, and document the path rules in `README.md`.

### Testing
- Ran `npm test -- src/test/UnitTests/RevealContext.jest.ts` and the suite passed (`4 passed`).
- Ran `npm run test-compile` (`tsc -p ./`) and TypeScript compilation succeeded.

Fixes #1406

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83efb6720832ca1f7892a75f9b751)