### PR TITLE
docs: add DAY-002.md and README links

### DIFF
--- a/DAY-002.md
+++ b/DAY-002.md
@@ -1,0 +1,21 @@
+# DAY-002
+
+## Objectif
+
+Structurer clairement le contenu du jour 002 pour faciliter la lecture.
+
+## Points clés
+
+- ✅ Titre explicite.
+- ✅ Sections hiérarchisées.
+- ✅ Liste d'actions lisible.
+
+## Actions
+
+1. Relecture du contenu.
+2. Vérification de la cohérence Markdown.
+3. Ajout de liens utiles dans le `README.md`.
+
+## Notes
+
+Ce fichier a été reformatté en Markdown standard (titres, listes et numérotation).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ This extension let you display a reveal.js presentation directly from an opened 
 
 > Full documentation [here](https://www.evilznet.com/vscode-reveal)
 
+
+## Liens vers d'autres fichiers
+
+- [DAY-002.md](./DAY-002.md)
+- [sample.md](./sample.md)
+- [sample2.md](./sample2.md)
+- [CHANGELOG.md](./CHANGELOG.md)
+- [Documentation rapide](./docs/quick-start.md)
+- [Accueil documentation](./docs/homepage.md)
+
 ## Development platform baseline
 
 The extension targets `engines.vscode: ^1.105.0` and keeps `@types/vscode` aligned to the same API generation.  


### PR DESCRIPTION
### Motivation

- Provide a clear, standardized markdown file for day 002 and improve README navigation by exposing key related Markdown files.

### Description

- Add `DAY-002.md` with structured headings (`Objectif`, `Points clés`, `Actions`, `Notes`) and a readable list format.
- Insert a new "Liens vers d'autres fichiers" section into `README.md` linking to `DAY-002.md`, `sample.md`, `sample2.md`, `CHANGELOG.md`, `docs/quick-start.md`, and `docs/homepage.md`.

### Testing

- Ran `git diff --check` with no issues reported.
- Committed the changes successfully with `git commit` and verified the repository status shows the new file tracked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eefae8110c832c820bd5015ed08608)