### PR TITLE
Improve CI validation and harden release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,20 @@
-name: continuous integration Build Matrix
+name: CI
 
 on:
   push:
   pull_request:
 
-jobs:
-  build:
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+permissions:
+  contents: read
 
+jobs:
+  validate:
+    name: Validate (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout repository
@@ -19,19 +23,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: .nvmrc
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Test
+      - name: Run tests with coverage
         run: npm run coverage
 
-      - name: Build project
+      - name: Build extension
         run: npm run vscode:prepublish
 
-      - name: Install vsce
-        run: npm install -g vsce
-
-      - name: Package extension smoke test
-        run: vsce package
+      - name: VSIX packaging smoke test
+        run: npx @vscode/vsce package --no-dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,6 @@ jobs:
       - name: Fail if release tag already exists
         env:
           TAG: ${{ steps.meta.outputs.tag }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           if git ls-remote --tags --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
             echo "Tag already exists: $TAG"
@@ -138,7 +137,7 @@ jobs:
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ needs.validate.outputs.package_name }}
+          extensionFile: vsix-package/${{ needs.validate.outputs.package_name }}
 
   publishOVSX:
     name: Publish to OpenVSX
@@ -155,7 +154,7 @@ jobs:
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           registryUrl: https://open-vsx.org
-          extensionFile: ${{ needs.validate.outputs.package_name }}
+          extensionFile: vsix-package/${{ needs.validate.outputs.package_name }}
 
   publishGH:
     name: Publish to GitHub Releases
@@ -176,4 +175,4 @@ jobs:
           tag_name: ${{ needs.validate.outputs.tag }}
           name: Release ${{ needs.validate.outputs.version }}
           generate_release_notes: true
-          files: ${{ needs.validate.outputs.package_name }}
+          files: vsix-package/${{ needs.validate.outputs.package_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,130 +1,179 @@
 name: Release
-# Release flow:
-# 1. package: builds a VSIX once and uploads it as an artifact.
-# 2. publishMS/publishOVSX/publishGH: optional publish jobs controlled by
-#    workflow_dispatch inputs and sharing the artifact from the package job.
-# Targets are kept unchanged: VS Marketplace, OpenVSX, and GitHub Releases.
+
 on:
   workflow_dispatch:
     inputs:
       publishMS:
-        description: 'Publish to MS marketplace'
+        description: Publish to VS Marketplace
         type: boolean
         required: true
         default: true
       publishOVSX:
-        description: 'Publish to OpenVSX'
+        description: Publish to OpenVSX
         type: boolean
         required: true
         default: true
       publishGH:
-        description: 'Publish to GitHub releases'
+        description: Publish to GitHub Releases
         type: boolean
         required: true
         default: true
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
-  package:
-    name: Package
+  validate:
+    name: Validate release inputs and build
     runs-on: ubuntu-latest
     outputs:
-      packageName: ${{ steps.setup.outputs.packageName }}
-      tag: ${{ steps.setup-tag.outputs.tag }}
-      version: ${{ steps.setup-tag.outputs.version }}
+      package_name: ${{ steps.meta.outputs.package_name }}
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: .nvmrc
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Install vsce
-        run: npm install -g vsce
-
-      - name: Setup package path
-        id: setup
+      - name: Validate package metadata
+        id: meta
+        shell: bash
         run: |
+          set -euo pipefail
           name="$(jq -r '.name' package.json)"
           version="$(jq -r '.version' package.json)"
-          echo "packageName=${name}-${version}.vsix" >> "$GITHUB_OUTPUT"
 
-      - name: Package
-        env:
-          VSIX_PACKAGE_PATH: ${{ steps.setup.outputs.packageName }}
-        run: vsce package
-      
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.setup.outputs.packageName }}
-          path: ${{ steps.setup.outputs.packageName }}
-      
-      - name: Setup tag
-        id: setup-tag
-        run: |
-          version="$(jq -r '.version' package.json)"
-          echo "tag: release/$version"
-          echo "tag=release/$version" >> "$GITHUB_OUTPUT"
+          if [[ -z "$name" || "$name" == "null" ]]; then
+            echo "package.json name is missing"
+            exit 1
+          fi
+
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "package.json version is missing"
+            exit 1
+          fi
+
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "package.json version is not a valid semver-like value: $version"
+            exit 1
+          fi
+
+          tag="release/$version"
+          echo "package_name=${name}-${version}.vsix" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if release tag already exists
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git ls-remote --tags --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag already exists: $TAG"
+            exit 1
+          fi
+
+      - name: Run tests with coverage
+        run: npm run coverage
+
+      - name: Build extension
+        run: npm run vscode:prepublish
+
+      - name: VSIX packaging smoke test
+        run: npx @vscode/vsce package --no-dependencies
+
+  package:
+    name: Package VSIX artifact
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension
+        run: npm run vscode:prepublish
+
+      - name: Create VSIX package
+        run: npx @vscode/vsce package --no-dependencies --out "${{ needs.validate.outputs.package_name }}"
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-package
+          path: ${{ needs.validate.outputs.package_name }}
 
   publishMS:
-    name: Publish to MS marketplace
+    name: Publish to VS Marketplace
     runs-on: ubuntu-latest
-    needs: package
+    needs: [validate, package]
     if: github.event.inputs.publishMS == 'true'
+    environment: visual-studio-marketplace
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.package.outputs.packageName }}
-      - uses: HaaLeo/publish-vscode-extension@v1
+          name: vsix-package
+
+      - uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ needs.package.outputs.packageName }}
-          packagePath: ''
+          extensionFile: ${{ needs.validate.outputs.package_name }}
 
   publishOVSX:
     name: Publish to OpenVSX
     runs-on: ubuntu-latest
-    needs: package
+    needs: [validate, package]
     if: github.event.inputs.publishOVSX == 'true'
+    environment: open-vsx
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.package.outputs.packageName }}
-      - uses: HaaLeo/publish-vscode-extension@v1
+          name: vsix-package
+
+      - uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           registryUrl: https://open-vsx.org
-          extensionFile: ${{ needs.package.outputs.packageName }}
-          packagePath: ''
-   
-  
+          extensionFile: ${{ needs.validate.outputs.package_name }}
+
   publishGH:
-    name: Publish to GitHub releases
+    name: Publish to GitHub Releases
     runs-on: ubuntu-latest
-    needs: package
+    needs: [validate, package]
     if: github.event.inputs.publishGH == 'true'
+    environment: github-releases
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.package.outputs.packageName }}
+          name: vsix-package
 
       - name: Create release and upload VSIX
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ needs.package.outputs.tag }}
-          name: Release ${{ needs.package.outputs.version }}
-          draft: false
-          prerelease: false
-          files: ${{ needs.package.outputs.packageName }}
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: Release ${{ needs.validate.outputs.version }}
+          generate_release_notes: true
+          files: ${{ needs.validate.outputs.package_name }}


### PR DESCRIPTION
### Motivation
- Keep CI focused on validation and speed by running tests and packaging smoke tests only on push and pull_request across the three main OSes.  
- Avoid duplicate packaging and reduce release risk by splitting validation and packaging, creating a single VSIX artifact, and reusing it for all publish targets.  
- Enforce least-privilege permissions and use dedicated GitHub Environments for publishing to ensure tokens are scoped to the appropriate environment.  
- Fail fast on invalid package metadata or when the release tag already exists to prevent accidental or duplicate releases.

### Description
- Replaced the old matrix build with a `CI` workflow that runs on `push` and `pull_request` and validates on `ubuntu-latest`, `windows-latest`, and `macos-latest` using `node-version-file: .nvmrc`, `npm ci`, `npm run coverage`, `npm run vscode:prepublish`, and a VSIX smoke test with `npx @vscode/vsce package --no-dependencies`.  
- Implemented a manual `Release` workflow (`workflow_dispatch`) that first runs a `validate` job to check `package.json` `name` and `version`, verify semver-like format, check that the release tag does not already exist, run tests, build, and run the VSIX smoke test.  
- Added a `package` job that creates the VSIX once on Ubuntu and uploads it as a single artifact named `vsix-package`, which is downloaded and reused by `publishMS`, `publishOVSX`, and `publishGH`.  
- Applied least-privilege permissions with `contents: read` at workflow level and `contents: write` only for the GitHub Releases job, added concurrency (`group: release-${{ github.repository }}`), attached publishing jobs to environments `visual-studio-marketplace`, `open-vsx`, and `github-releases`, and switched to `HaaLeo/publish-vscode-extension@v2` plus `softprops/action-gh-release@v2` with autogenerated release notes.

### Testing
- Verified repository changes and staged files with `git status --short`, which completed successfully.  
- Inspected and validated diffs for the two workflow files using `git diff -- .github/workflows/build.yml .github/workflows/release.yaml | sed -n '1,260p'`, which completed successfully.  
- Committed the workflow updates with `git add` and `git commit -m "Improve CI and release GitHub Actions workflows"`, which completed successfully.  
- Printed the final workflow files with `nl -ba .github/workflows/build.yml` and `nl -ba .github/workflows/release.yaml` to verify contents, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e0c48fbc832c909ae20e61498440)