### PR TITLE
Fix status bar server info (1126) and log server URI (1374)

### DIFF
--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -327,7 +327,13 @@ export default class MainController {
 
   /** Stop server from listening */
   public stopServer() {
+    const currentServerUri = this.currentContext?.baseUri || null
     this.currentContext?.stopServer()
+
+    if (currentServerUri) {
+      this.statusBarController.updateServerInfo(`__stopped__:${currentServerUri}`)
+    }
+
     this.statusBarController.updateServerInfo(null)
   }
 }

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -74,6 +74,7 @@ export default class MainController {
   private OnEditorEvent(editor: TextEditor, newPosition: Position) {
     if (isMarkdownFile(editor.document)) {
       this.currentContext = this.revealContexts.getOrAdd(editor)
+      this.statusBarController.updateServerInfo(this.currentContext?.baseUri || null)
       this.updatePosition(newPosition)
       this.refresh()
     }
@@ -137,7 +138,17 @@ export default class MainController {
       () => this.config,
       extensionContext.extensionPath,
       this.isInExport,
-      this.onExportError
+      this.onExportError,
+      (uri, context) => {
+        if (this.currentContext === context) {
+          this.statusBarController.updateServerInfo(uri || null)
+        }
+      },
+      (context) => {
+        if (this.currentContext === context) {
+          this.statusBarController.updateServerInfo(null)
+        }
+      }
     )
     this.diagnostics = languages.createDiagnosticCollection('vscode-revealjs')
     this.configByKey = new Map(configDesc.map((d) => [d.label, d]))
@@ -218,13 +229,9 @@ export default class MainController {
       const diagnostics = await collectDiagnostics(context, this.configByKey)
       this.diagnostics.set(context.editor.document.uri, diagnostics)
 
-      const hadOpenWebViewPane = !!this.webViewPane
       this.refreshWebViewPane()
       this.slidesExplorer.update()
       this.statusBarController.updateCount(slides.length)
-      if (!hadOpenWebViewPane) {
-        this.statusBarController.updateServerInfo(context.baseUri || null)
-      }
       this.textDecorator.update(context.editor)
       this.logger.info(`REFRESH DONE!`)
     }, wait)
@@ -322,18 +329,10 @@ export default class MainController {
   /** Start server on an available port */
   public startServer() {
     this.currentContext?.startServer()
-    this.statusBarController.updateServerInfo(this.currentContext?.baseUri || null)
   }
 
   /** Stop server from listening */
   public stopServer() {
-    const currentServerUri = this.currentContext?.baseUri || null
     this.currentContext?.stopServer()
-
-    if (currentServerUri) {
-      this.statusBarController.updateServerInfo(`__stopped__:${currentServerUri}`)
-    }
-
-    this.statusBarController.updateServerInfo(null)
   }
 }

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -221,6 +221,7 @@ export default class MainController {
       this.refreshWebViewPane()
       this.slidesExplorer.update()
       this.statusBarController.updateCount(slides.length)
+      this.statusBarController.updateServerInfo(context.baseUri || null)
       this.textDecorator.update(context.editor)
       this.logger.info(`REFRESH DONE!`)
     }, wait)
@@ -318,10 +319,12 @@ export default class MainController {
   /** Start server on an available port */
   public startServer() {
     this.currentContext?.startServer()
+    this.statusBarController.updateServerInfo(this.currentContext?.baseUri || null)
   }
 
   /** Stop server from listening */
   public stopServer() {
     this.currentContext?.stopServer()
+    this.statusBarController.updateServerInfo(null)
   }
 }

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -218,10 +218,13 @@ export default class MainController {
       const diagnostics = await collectDiagnostics(context, this.configByKey)
       this.diagnostics.set(context.editor.document.uri, diagnostics)
 
+      const hadOpenWebViewPane = !!this.webViewPane
       this.refreshWebViewPane()
       this.slidesExplorer.update()
       this.statusBarController.updateCount(slides.length)
-      this.statusBarController.updateServerInfo(context.baseUri || null)
+      if (!hadOpenWebViewPane) {
+        this.statusBarController.updateServerInfo(context.baseUri || null)
+      }
       this.textDecorator.update(context.editor)
       this.logger.info(`REFRESH DONE!`)
     }, wait)

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -147,6 +147,14 @@ export class RevealContext extends Disposable {
     this.#server.stop()
   }
 
+  public get onDidStartServer() {
+    return this.#server.onDidStart
+  }
+
+  public get onDidStopServer() {
+    return this.#server.onDidStop
+  }
+
   private readonly _onDidDispose = this._register(new EventEmitter<void>())
   /**
    * Fired when the document is disposed of.
@@ -172,7 +180,9 @@ export class RevealContexts {
     private readonly getConfiguration: () => Configuration,
     private readonly extensionPath: string,
     private readonly isInExport: () => boolean,
-    private readonly onExportError: (error: unknown) => void
+    private readonly onExportError: (error: unknown) => void,
+    private readonly onServerStart: (uri: string, context: RevealContext) => void,
+    private readonly onServerStop: (context: RevealContext) => void
   ) {
     this.logger = logger
   }
@@ -182,6 +192,8 @@ export class RevealContexts {
     const context = new RevealContext(editor, this.logger, this.getConfiguration, this.extensionPath, this.isInExport, this.onExportError)
 
     context.onDidDispose(() => this.logger.info(`CONTEXT: ${editor.document.uri} disposed`))
+    context.onDidStartServer((uri) => this.onServerStart(uri, context))
+    context.onDidStopServer(() => this.onServerStop(context))
 
     this.innerMap.set(editor.document.uri, context)
     return context

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -9,10 +9,17 @@ import markdownit, { setDiagramRenderingConfig } from './Markdown-it'
 import { exportHTML, IExportOptions } from './ExportHTML'
 import { Disposable } from './dispose'
 import { RevealContext } from './RevealContext'
+import { EventEmitter } from 'vscode'
 
 /** Http server to serve reveal presentation */
 export class RevealServer extends Disposable {
   public readonly app = express()
+
+  private readonly _onDidStart = this._register(new EventEmitter<string>())
+  public readonly onDidStart = this._onDidStart.event
+
+  private readonly _onDidStop = this._register(new EventEmitter<void>())
+  public readonly onDidStop = this._onDidStop.event
 
   private server: http.Server | null = null
   private readonly host = 'localhost'
@@ -30,7 +37,10 @@ export class RevealServer extends Disposable {
     try {
       if (!this.isListening) {
         this.server = this.app.listen(0)
-        this.context.logger.info(`SERVER started at ${this.uri}`)
+        this.server?.on('listening', () => {
+          this.context.logger.info('SERVER started at ' + this.uri)
+          this._onDidStart.fire(this.uri)
+        })
       }
     } catch (err) {
       const error = new Error(`Cannot start server: ${err}`)
@@ -50,6 +60,7 @@ export class RevealServer extends Disposable {
     if (this.isListening && this.server) {
       this.server.close()
       this.context.logger.debug(`SERVER: stopped`)
+      this._onDidStop.fire()
     }
   }
 

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -30,7 +30,7 @@ export class RevealServer extends Disposable {
     try {
       if (!this.isListening) {
         this.server = this.app.listen(0)
-        this.context.logger.info(`SERVER started`)
+        this.context.logger.info(`SERVER started at ${this.uri}`)
       }
     } catch (err) {
       const error = new Error(`Cannot start server: ${err}`)

--- a/src/StatusBarController.ts
+++ b/src/StatusBarController.ts
@@ -39,12 +39,15 @@ export class StatusBarController extends Disposable{
   }
 
   public updateServerInfo(serverUri: string | null) {
-    if (serverUri !== null && serverUri !== this.#currentServerUri) {
-      this.#currentServerUri = serverUri
-      this.#addressItem.text = `$(server) ${serverUri}`
+    if (serverUri !== null) {
+      if (serverUri !== this.#currentServerUri) {
+        this.#currentServerUri = serverUri
+        this.#addressItem.text = `$(server) ${serverUri}`
+      }
       this.#addressItem.show()
       this.#stopItem.show()
     } else {
+      this.#currentServerUri = null
       this.#addressItem.text = ''
       this.#addressItem.hide()
       this.#stopItem.hide()

--- a/src/test/UnitTests/MainController.jest.ts
+++ b/src/test/UnitTests/MainController.jest.ts
@@ -72,9 +72,11 @@ jest.mock('../../SlideExplorer', () => ({
 }))
 
 const statusBarUpdateCountMock = jest.fn()
+const statusBarUpdateServerInfoMock = jest.fn()
 jest.mock('../../StatusBarController', () => ({
   StatusBarController: jest.fn().mockImplementation(() => ({
     updateCount: statusBarUpdateCountMock,
+    updateServerInfo: statusBarUpdateServerInfoMock,
   })),
 }))
 

--- a/src/test/UnitTests/RevealContext.jest.ts
+++ b/src/test/UnitTests/RevealContext.jest.ts
@@ -17,6 +17,8 @@ jest.mock('../../RevealServer', () => ({
     uri: 'http://localhost:1948/',
     start: (...args: unknown[]) => (serverStartMock as any)(...args),
     stop: (...args: unknown[]) => (serverStopMock as any)(...args),
+    onDidStart: jest.fn(),
+    onDidStop: jest.fn(),
     dispose: jest.fn(),
   })),
 }))
@@ -182,7 +184,7 @@ describe('RevealContext', () => {
 describe('RevealContexts', () => {
   test('adds, reuses and removes contexts', () => {
     const logger = { info: jest.fn(), debug: jest.fn(), LogLevel: LogLevel.Error }
-    const contexts = new RevealContexts(logger as any, () => defaultConfiguration, '/ext', () => false, () => {})
+    const contexts = new RevealContexts(logger as any, () => defaultConfiguration, '/ext', () => false, () => {}, () => {}, () => {})
 
     const editor = {
       document: {

--- a/src/test/UnitTests/StatusBarController.jest.ts
+++ b/src/test/UnitTests/StatusBarController.jest.ts
@@ -52,13 +52,14 @@ describe('StatusBarController', () => {
     expect(stopItem.show).toHaveBeenCalledTimes(1)
 
     controller.updateServerInfo('http://localhost:1948')
-    expect(addressItem.text).toBe('')
-    expect(addressItem.hide).toHaveBeenCalledTimes(2)
-    expect(stopItem.hide).toHaveBeenCalledTimes(2)
+    expect(addressItem.text).toBe('$(server) http://localhost:1948')
+    expect(addressItem.show).toHaveBeenCalledTimes(2)
+    expect(stopItem.show).toHaveBeenCalledTimes(2)
+    expect(addressItem.hide).toHaveBeenCalledTimes(1) // from constructor
 
     controller.updateServerInfo(null)
-    expect(addressItem.hide).toHaveBeenCalledTimes(3)
-    expect(stopItem.hide).toHaveBeenCalledTimes(3)
+    expect(addressItem.hide).toHaveBeenCalledTimes(2)
+    expect(stopItem.hide).toHaveBeenCalledTimes(2)
   })
 
   test('updateCount updates singular/plural and hides for invalid counts', () => {


### PR DESCRIPTION
This PR fixes two issues:
- Fixes #1126: Calls \updateServerInfo\ in \MainController.ts\ to ensure the server URL and port are displayed in the status bar when the preview server starts or refreshes.
- Fixes #1374: Modifies \RevealServer.ts\ to log the full URL of the server upon startup, so the port can be easily seen in the Output tab for SSH/remote users.