### PR TITLE
Fix slide number format strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,9 +277,12 @@
           "description": "Display a presentation progress bar"
         },
         "revealjs.slideNumber": {
-          "type": "boolean",
+          "type": [
+            "boolean",
+            "string"
+          ],
           "default": false,
-          "description": "Display the page number of the current slide"
+          "description": "Display the page number of the current slide. Use a Reveal.js format string such as h/v, h.v, c, or c/t to control formatting."
         },
         "revealjs.history": {
           "type": "boolean",

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -36,7 +36,7 @@ export interface IRevealOptions {
   customHighlightTheme: string | null
   controls: boolean
   progress: boolean
-  slideNumber: boolean
+  slideNumber: boolean | string
   history: boolean
   keyboard: boolean
   overview: boolean

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -179,6 +179,18 @@ describe('RevealServer', () => {
     context.dispose()
   })
 
+  test('renders slide number format strings as JavaScript strings', async () => {
+    const context = createContext({ configuration: { slideNumber: 'h/v' } })
+    const server = new RevealServer(context)
+
+    const response = await request(server.app).get('/')
+
+    expect(response.text).toContain('slideNumber: "h/v"')
+
+    server.dispose()
+    context.dispose()
+  })
+
   test('serves rendered bundled assets through static middleware', async () => {
     const context = createContext()
     const server = new RevealServer(context)

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -46,7 +46,7 @@
       controlsLayout: '<%= controlsLayout %>',
       controlsBackArrows: '<%= controlsBackArrows %>',
       progress: <%= progress %>,
-      slideNumber: <%= slideNumber %>,
+      slideNumber: <%- JSON.stringify(slideNumber) %>,
       //#showSlideNumber "all" "print" "speaker"
       hash: true, //# hash: false,
       //# respondToHashChanges: true,


### PR DESCRIPTION
## Summary
- Allow `revealjs.slideNumber` to be either a boolean or a Reveal.js format string.
- Render the option with `JSON.stringify()` so values such as `h/v` are emitted as valid JavaScript strings.
- Add a regression test for the generated `Reveal.initialize()` configuration.

## Root cause
`slideNumber` was typed and contributed as a boolean only, and `views/init.ejs` inserted it unquoted. A front matter value such as `slideNumber: "h/v"` rendered as `slideNumber: h/v`, which is invalid JavaScript and prevented Reveal.js slide-number formats from working.

## Validation
- `npm test -- --runInBand src/test/UnitTests/RevealServer.jest.ts -t "renders slide number format"`
- `npm test -- --runInBand src/test/UnitTests/Configuration.jest.ts`
- `npm run test-compile`
- `npm test -- --runInBand`

Fixes #1050