### PR TITLE
Preserve escaped braces in inline LaTeX

### DIFF
--- a/src/Markdown-it.ts
+++ b/src/Markdown-it.ts
@@ -88,7 +88,13 @@ const preserveInlineMath = (state, silent) => {
 
   let match = start + 1
   while ((match = state.src.indexOf('$', match)) !== -1) {
-    if (state.src.charCodeAt(match - 1) === 0x5c /* \ */) {
+    let backslashCount = 0
+    let pos = match - 1
+    while (pos >= 0 && state.src.charCodeAt(pos) === 0x5c /* \ */) {
+      backslashCount++
+      pos--
+    }
+    if (backslashCount % 2 === 1) {
       match += 1
       continue
     }

--- a/src/Markdown-it.ts
+++ b/src/Markdown-it.ts
@@ -81,6 +81,35 @@ const note = (markdown, config) => {
   }
 }
 
+const preserveInlineMath = (state, silent) => {
+  const start = state.pos
+  if (state.src.charCodeAt(start) !== 0x24 /* $ */) return false
+  if (state.src.charCodeAt(start + 1) === 0x24 /* $ */) return false
+
+  let match = start + 1
+  while ((match = state.src.indexOf('$', match)) !== -1) {
+    if (state.src.charCodeAt(match - 1) === 0x5c /* \ */) {
+      match += 1
+      continue
+    }
+
+    if (match === start + 1) return false
+
+    if (!silent) {
+      const token = state.push('text', '', 0)
+      token.content = state.src.slice(start, match + 1)
+    }
+    state.pos = match + 1
+    return true
+  }
+
+  return false
+}
+
+const math = (markdown) => {
+  markdown.inline.ruler.before('escape', 'preserve_inline_math', preserveInlineMath)
+}
+
 
 const diagramTypes = [
   'blockdiag',
@@ -129,6 +158,7 @@ const markdown = md({
     .use(samp)
     .use(sub)
     .use(sup)
+    .use(math)
     .use(note, { notesSeparator })
 
 // add kroki

--- a/src/test/UnitTests/MarkdownItDiagramServer.jest.ts
+++ b/src/test/UnitTests/MarkdownItDiagramServer.jest.ts
@@ -34,4 +34,9 @@ describe('Markdown-it diagram server configuration', () => {
     expect(html).toContain('<p>Paragraph text</p>')
     expect(html).toContain('<aside class="notes"> this is speaker only</aside>')
   })
+
+  test('preserves escaped braces in inline LaTeX expressions', () => {
+    const html = markdownit.render('$\\{x\\}$')
+    expect(html).toContain('$\\{x\\}$')
+  })
 })

--- a/src/test/UnitTests/MarkdownItDiagramServer.jest.ts
+++ b/src/test/UnitTests/MarkdownItDiagramServer.jest.ts
@@ -39,4 +39,14 @@ describe('Markdown-it diagram server configuration', () => {
     const html = markdownit.render('$\\{x\\}$')
     expect(html).toContain('$\\{x\\}$')
   })
+
+  test('preserves inline math spanning an escaped dollar sign', () => {
+    const html = markdownit.render('$a \\$ b$')
+    expect(html).toContain('$a \\$ b$')
+  })
+
+  test('preserves inline math when closing delimiter follows even number of backslashes', () => {
+    const html = markdownit.render('$x\\\\$')
+    expect(html).toContain('$x\\\\$')
+  })
 })


### PR DESCRIPTION
## Summary
- Preserve inline `$...$` math spans before Markdown-it's escape rule consumes backslashes.
- Keep escaped LaTeX braces such as `$\\{x\\}$` intact for MathJax.
- Add a regression test for inline LaTeX escaped braces.

## Root cause
Markdown-it treats backslash-prefixed punctuation as Markdown escapes. For `$\\{x\\}$`, it removed the backslashes before braces and emitted `${x}$`, so MathJax did not receive the intended escaped braces.

## Validation
- `npm test -- --runInBand src/test/UnitTests/MarkdownItDiagramServer.jest.ts -t "preserves escaped braces"`
- `npm run test-compile`
- `npm test -- --runInBand`

Fixes #1257