### PR TITLE
Use bundled Font Awesome assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
 
 	
 	
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+	<link rel="stylesheet" href="libs/reveal.js/6.0.1/plugin/menu/font-awesome/css/all.css">
+	<link rel="stylesheet" href="libs/reveal.js/6.0.1/plugin/menu/font-awesome/css/v4-shims.min.css">
 
 	  <!-- highlight Theme -->
   	

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<link rel="stylesheet" href="libs/reveal.js/4.1.3/reset.css">
-	<link rel="stylesheet" href="libs/reveal.js/4.1.3/reveal.css">
+	<link rel="stylesheet" href="libs/reveal.js/6.0.1/reset.css">
+	<link rel="stylesheet" href="libs/reveal.js/6.0.1/reveal.css">
 
 	
 	
@@ -28,11 +28,11 @@
 	
 	
 		
-	<link rel="stylesheet" href="libs/reveal.js/4.1.3/plugin/chalkboard/style.css">
+	<link rel="stylesheet" href="libs/reveal.js/6.0.1/plugin/chalkboard/style.css">
 	
 	
 	
-		<link rel="stylesheet" href="libs/reveal.js/4.1.3/plugin/customcontrols/style.css">
+		<link rel="stylesheet" href="libs/reveal.js/6.0.1/plugin/customcontrols/style.css">
 	
 	<link rel="stylesheet" href="libs/styles/tasklist.css">
 
@@ -40,7 +40,7 @@
 
   <!-- Revealjs Theme -->
   
-  	<link rel="stylesheet" href="libs/reveal.js/4.1.3/theme/black.css" id="theme">
+  	<link rel="stylesheet" href="libs/reveal.js/6.0.1/theme/black.css" id="theme">
   
   
 
@@ -68,32 +68,31 @@
   </div>
 
   	
-	<script src="libs/reveal.js/4.1.3/reveal.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/zoom/zoom.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/notes/notes.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/search/search.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/markdown/markdown.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/highlight/highlight.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/menu/menu.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/math/math.js"></script>
+	<script src="libs/reveal.js/6.0.1/reveal.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/zoom.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/notes.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/search.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/markdown.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/highlight.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/menu/menu.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/math.js"></script>
 
-	<script src="libs/reveal.js/4.1.3/plugin/fullscreen/plugin.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/fullscreen/plugin.js"></script>
   
-  	<script src="libs/reveal.js/4.1.3/plugin/animate/plugin.js"></script>
-  	<script src="libs/reveal.js/4.1.3/plugin/animate/svg.min.js"></script>
+  	<script src="libs/reveal.js/6.0.1/plugin/animate/plugin.js"></script>
+  	<script src="libs/reveal.js/6.0.1/plugin/animate/svg.min.js"></script>
   
-  	 <!--	<script src="libs/reveal.js/4.1.3/plugin/anything/plugin.js"></script> -->
+  	 <!--	<script src="libs/reveal.js/6.0.1/plugin/anything/plugin.js"></script> -->
 
- <!--	<script src="libs/reveal.js/4.1.3/plugin/audio-slideshow/plugin.js"></script>  -->
-<!--	<script src="libs/reveal.js/4.1.3/plugin/audio-slideshow/recorder.js"></script>-->
-<!--	<script src="libs/reveal.js/4.1.3/plugin/audio-slideshow/RecordRTC.js"></script>-->
+ <!--	<script src="libs/reveal.js/6.0.1/plugin/audio-slideshow/plugin.js"></script>  -->
+<!--	<script src="libs/reveal.js/6.0.1/plugin/audio-slideshow/recorder.js"></script>-->
+<!--	<script src="libs/reveal.js/6.0.1/plugin/audio-slideshow/RecordRTC.js"></script>-->
 
-<script src="libs/reveal.js/4.1.3/plugin/chalkboard/plugin.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/customcontrols/plugin.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/embed-tweet/plugin.js"></script>
+<script src="libs/reveal.js/6.0.1/plugin/chalkboard/plugin.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/customcontrols/plugin.js"></script>
 
-	<script src="libs/reveal.js/4.1.3/plugin/chart/chart.min.js"></script>
-	<script src="libs/reveal.js/4.1.3/plugin/chart/plugin.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/chart/chart.min.js"></script>
+	<script src="libs/reveal.js/6.0.1/plugin/chart/plugin.js"></script>
 
   <script>
 
@@ -103,7 +102,6 @@
 			RevealMath,
 			RevealAnimate,
 			RevealChalkboard, 
-			RevealEmbedTweet,
 			RevealChart,
 		];
 
@@ -212,6 +210,9 @@
 			chalkboard: { // font-awesome.min.css must be available
 					//src: "chalkboard/chalkboard.json",
 					storage: "chalkboard-demo",
+				},
+			menu: {
+					path: 'libs/reveal.js/6.0.1/plugin/menu/',
 				},
 			
 			customcontrols: {

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -84,6 +84,9 @@ describe('RevealServer', () => {
 
     expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/markdown.js')
     expect(response.text).not.toContain('libs/reveal.js/6.0.1/plugin/markdown/markdown.js')
+    expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/menu/font-awesome/css/all.css')
+    expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/menu/font-awesome/css/v4-shims.min.css')
+    expect(response.text).not.toContain('maxcdn.bootstrapcdn.com/font-awesome')
     expect(missingAssets).toEqual([])
 
     server.dispose()

--- a/views/head.ejs
+++ b/views/head.ejs
@@ -14,7 +14,8 @@
   <link rel="stylesheet" href="libs/reveal.js/6.0.1/reset.css">
   <link rel="stylesheet" href="libs/reveal.js/6.0.1/reveal.css">
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="libs/reveal.js/6.0.1/plugin/menu/font-awesome/css/all.css">
+  <link rel="stylesheet" href="libs/reveal.js/6.0.1/plugin/menu/font-awesome/css/v4-shims.min.css">
 
   <!-- highlight Theme -->
   <% if (highlightTheme) { %>


### PR DESCRIPTION
## Summary
- Replace the external Font Awesome CDN stylesheet with bundled Font Awesome CSS from the vendored reveal-menu plugin.
- Include `v4-shims.min.css` so existing `fa fa-*` control icon classes continue to resolve.
- Extend the server asset test to assert the generated presentation uses bundled Font Awesome and no longer references `maxcdn.bootstrapcdn.com`.

## Root cause
The preview/export HTML depended on `https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css`. Exported presentations did not vendor that CDN resource, so controls could render as empty squares when offline or when the CDN was unavailable.

## Validation
- `npm test -- --runInBand src/test/UnitTests/RevealServer.jest.ts -t "root request references only bundled local assets"`
- `npm run test-compile`
- `npm test -- --runInBand`

Fixes #1032