### PR TITLE
Support Reveal keyboard config objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,9 +287,12 @@
           "description": "Push each slide change to the browser history"
         },
         "revealjs.keyboard": {
-          "type": "boolean",
+          "type": [
+            "boolean",
+            "object"
+          ],
           "default": true,
-          "description": "Enable keyboard shortcuts for navigation"
+          "description": "Enable keyboard shortcuts for navigation, or provide a Reveal.js keyboard mapping object"
         },
         "revealjs.overview": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -294,6 +294,12 @@
             "boolean",
             "object"
           ],
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "default": true,
           "description": "Enable keyboard shortcuts for navigation, or provide a Reveal.js keyboard mapping object"
         },

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -38,7 +38,7 @@ export interface IRevealOptions {
   progress: boolean
   slideNumber: boolean
   history: boolean
-  keyboard: boolean
+  keyboard: boolean | Record<string, unknown>
   overview: boolean
   center: boolean
   touch: boolean

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -38,7 +38,7 @@ export interface IRevealOptions {
   progress: boolean
   slideNumber: boolean | string
   history: boolean
-  keyboard: boolean | Record<string, unknown>
+  keyboard: boolean | Record<string, string | null>
   overview: boolean
   center: boolean
   touch: boolean

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -11,6 +11,11 @@ import { Disposable } from './dispose'
 import { RevealContext } from './RevealContext'
 import { EventEmitter } from 'vscode'
 
+export const jsonForScript = (value: unknown): string => JSON.stringify(value)
+  .replace(/</g, '\\u003c')
+  .replace(/\u2028/g, '\\u2028')
+  .replace(/\u2029/g, '\\u2029')
+
 /** Http server to serve reveal presentation */
 export class RevealServer extends Disposable {
   public readonly app = express()
@@ -140,7 +145,7 @@ export class RevealServer extends Disposable {
           html: markdownit.render(s.text),
           children: s.verticalChildren.map((c) => ({ ...c, html: markdownit.render(c.text) })),
         }))
-        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init, initModule })
+        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init, initModule, jsonForScript })
       }
     })
 

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -355,8 +355,8 @@ describe('RevealServer', () => {
     const next = jest.fn()
     const req = { originalUrl: '/index.html?x=1' }
     const res: TestResponse = {
-      write: jest.fn((_chunk: string) => true),
-      end: jest.fn((_chunk: string) => true),
+      write: jest.fn((chunk: string) => typeof chunk === 'string'),
+      end: jest.fn((chunk: string) => typeof chunk === 'string'),
     }
 
     await middleware(req, res, next)

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -201,8 +201,9 @@ describe('RevealServer', () => {
     const context = createContext({
       configuration: {
         keyboard: {
-          66: 'Reveal.togglePause',
+          66: 'togglePause',
           191: null,
+          192: '</script>\u2028\u2029',
         },
       },
     })
@@ -210,7 +211,8 @@ describe('RevealServer', () => {
 
     const response = await request(server.app).get('/')
 
-    expect(response.text).toContain('keyboard: {"66":"Reveal.togglePause","191":null}')
+    expect(response.text).toContain('keyboard: {"66":"togglePause","191":null,"192":"\\u003c/script>\\u2028\\u2029"}')
+    expect(response.text).not.toContain('"192":"</script>')
 
     server.dispose()
     context.dispose()

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -11,6 +11,8 @@ import * as os from 'os'
 
 const localAssetPattern = /(?:href|src)="(libs\/[^"]+)"/g
 const collectLocalAssets = (html: string) => [...html.matchAll(localAssetPattern)].map((match) => match[1])
+const tempDirectoryPrefix = 'vscode-reveal-'
+const moduleInitSource = 'import "./plugin.js";'
 
 const createContext = (options?: { inExport?: boolean; dirname?: string; onExportError?: (error: unknown) => void; configuration?: Partial<Configuration> & Record<string, unknown> }) => {
   const logger = new Logger(() => undefined, LogLevel.Error)
@@ -94,7 +96,7 @@ describe('RevealServer', () => {
         slideNumber: 'h/v',
         pdfSeparateFragments: false,
         pdfMaxPagesPerSlide: 1,
-      } as any,
+      },
     })
     const server = new RevealServer(context)
 
@@ -276,7 +278,7 @@ describe('RevealServer', () => {
   })
 
   test('loads init.js content when present in markdown folder', async () => {
-    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-'))
+    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), tempDirectoryPrefix))
     let context: RevealContext | undefined
     let server: RevealServer | undefined
     try {
@@ -296,19 +298,19 @@ describe('RevealServer', () => {
   })
 
   test('loads init.esm.js as a module when present in markdown folder', async () => {
-    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-'))
+    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), tempDirectoryPrefix))
     let context: RevealContext | undefined
     let server: RevealServer | undefined
     try {
       const initPath = path.join(dirname, 'init.esm.js')
-      await fs.writeFile(initPath, 'import "./plugin.js";')
+      await fs.writeFile(initPath, moduleInitSource)
       context = createContext({ dirname })
       server = new RevealServer(context)
       const response = await request(server.app).get('/')
 
       expect(response.status).toEqual(200)
       expect(response.text).toContain('<script type="module" src="init.esm.js"></script>')
-      expect(response.text).not.toContain('import "./plugin.js";')
+      expect(response.text).not.toContain(moduleInitSource)
     } finally {
       server?.dispose()
       context?.dispose()
@@ -317,12 +319,12 @@ describe('RevealServer', () => {
   })
 
   test('prefers init.esm.js over init.js when both are present', async () => {
-    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-'))
+    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), tempDirectoryPrefix))
     let context: RevealContext | undefined
     let server: RevealServer | undefined
     try {
       await fs.writeFile(path.join(dirname, 'init.js'), 'window.legacyInitLoaded = true;')
-      await fs.writeFile(path.join(dirname, 'init.esm.js'), 'import "./plugin.js";')
+      await fs.writeFile(path.join(dirname, 'init.esm.js'), moduleInitSource)
       context = createContext({ dirname })
       server = new RevealServer(context)
       const response = await request(server.app).get('/')
@@ -344,17 +346,22 @@ describe('RevealServer', () => {
     const exporter = jest.fn(async () => {
       throw new Error('boom')
     })
-    const middleware = (server as any).exportMiddleware(exporter, () => true) as (req: any, res: any, next: () => void) => Promise<void>
+    type TestRequest = { originalUrl: string }
+    type TestResponse = { write: (chunk: string) => boolean; end: (chunk: string) => boolean | Promise<boolean> }
+    type ExportMiddleware = (req: TestRequest, res: TestResponse, next: () => void) => Promise<void>
+    const middleware = (server as unknown as {
+      exportMiddleware: (exportFn: typeof exporter, isInExport: () => boolean) => ExportMiddleware
+    }).exportMiddleware(exporter, () => true)
     const next = jest.fn()
     const req = { originalUrl: '/index.html?x=1' }
-    const res = {
-      write: jest.fn(() => true),
-      end: jest.fn(() => true),
+    const res: TestResponse = {
+      write: jest.fn((_chunk: string) => true),
+      end: jest.fn((_chunk: string) => true),
     }
 
     await middleware(req, res, next)
-    await (res.write as any)('<html>')
-    await (res.end as any)('</html>')
+    await res.write('<html>')
+    await res.end('</html>')
 
     expect(next).toHaveBeenCalledTimes(1)
     expect(exporter).toHaveBeenCalledTimes(1)

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -179,6 +179,25 @@ describe('RevealServer', () => {
     context.dispose()
   })
 
+  test('renders keyboard object configuration as JavaScript object', async () => {
+    const context = createContext({
+      configuration: {
+        keyboard: {
+          66: 'Reveal.togglePause',
+          191: null,
+        },
+      },
+    })
+    const server = new RevealServer(context)
+
+    const response = await request(server.app).get('/')
+
+    expect(response.text).toContain('keyboard: {"66":"Reveal.togglePause","191":null}')
+
+    server.dispose()
+    context.dispose()
+  })
+
   test('serves rendered bundled assets through static middleware', async () => {
     const context = createContext()
     const server = new RevealServer(context)

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -53,7 +53,7 @@
       hash: true, //# hash: false,
       //# respondToHashChanges: true,
       //# history: false,
-      keyboard: <%- JSON.stringify(keyboard) %>,
+      keyboard: <%- jsonForScript(keyboard) %>,
       //#keyboardCondition: null,
       overview: <%= overview %>,
       center: <%= center %>,

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -51,7 +51,7 @@
       hash: true, //# hash: false,
       //# respondToHashChanges: true,
       //# history: false,
-      keyboard: <%= keyboard %>,
+      keyboard: <%- JSON.stringify(keyboard) %>,
       //#keyboardCondition: null,
       overview: <%= overview %>,
       center: <%= center %>,


### PR DESCRIPTION
## Summary
- Allow `revealjs.keyboard` to be either a boolean or a Reveal.js keyboard mapping object.
- Render `keyboard` with `JSON.stringify()` so object values are emitted as valid JavaScript.
- Add a server rendering regression test for keyboard object configuration.

## Root cause
The extension typed and contributed `keyboard` as a boolean only, and the EJS template interpolated it directly. A front matter object for custom Reveal keyboard bindings could not type-check and would render as invalid JavaScript.

## Validation
- `npm test -- --runInBand src/test/UnitTests/RevealServer.jest.ts -t "keyboard object"`
- `npm test -- --runInBand src/test/UnitTests/Configuration.jest.ts`
- `npm run test-compile`
- `npm test -- --runInBand`

Fixes #765