### PR TITLE
Add local HTML fragment injection option

### DIFF
--- a/package.json
+++ b/package.json
@@ -507,6 +507,14 @@
           "default": "Reveal JS presentation",
           "description": "Title of your presentation"
         },
+        "revealjs.htmlFragment": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Local HTML fragment file to inject into the rendered presentation body, resolved relative to the markdown file"
+        },
         "revealjs.css": {
           "type": "array",
           "default": [],

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -76,6 +76,7 @@ export interface IRevealOptions {
   logoImg: string | null
   description: string
   author: string
+  htmlFragment: string | null
 
   enableMenu: boolean
   enableChalkboard: boolean
@@ -108,6 +109,7 @@ export const defaultConfiguration: Configuration = {
   logoImg: null,
   description: '',
   author: '',
+  htmlFragment: null,
   notesSeparator: 'note:',
   separator: '^\\r?\\n---\\r?\\n$',
   verticalSeparator: '^\\r?\\n--\\r?\\n$',

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -90,6 +90,11 @@ export class RevealContext extends Disposable {
       paths.add(customThemePath)
     }
 
+    const htmlFragmentPath = this.resolveLocalAssetPath(this.configuration.htmlFragment)
+    if (htmlFragmentPath) {
+      paths.add(htmlFragmentPath)
+    }
+
     const cssAssetPaths = Array.isArray(this.configuration.css) ? this.configuration.css : []
     for (const cssAssetPath of cssAssetPaths) {
       const resolvedPath = this.resolveLocalAssetPath(cssAssetPath)

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -85,6 +85,40 @@ export class RevealServer extends Disposable {
     return `http://${this.host}:${addr.port}/`
   }
 
+  private loadInitScript(): { init: string | null; initModule: boolean } {
+    const initModulePath = path.join(this.context.dirname, 'init.esm.js')
+    if (fs.existsSync(initModulePath)) {
+      return { init: 'init.esm.js', initModule: true }
+    }
+
+    const initPath = path.join(this.context.dirname, 'init.js')
+    return fs.existsSync(initPath)
+      ? { init: fs.readFileSync(initPath, 'utf8'), initModule: false }
+      : { init: null, initModule: false }
+  }
+
+  private loadHtmlFragmentContent(): string | null {
+    const configuredFragmentPath = this.context.configuration.htmlFragment
+    if (!configuredFragmentPath) return null
+
+    const htmlFragmentPath = this.context.resolvePresentationFilePath(configuredFragmentPath)
+    if (!htmlFragmentPath) {
+      this.context.logger.error(`HTML fragment path must stay inside the presentation directory: ${configuredFragmentPath}`)
+      return null
+    }
+
+    try {
+      if (!fs.statSync(htmlFragmentPath).isFile()) {
+        this.context.logger.error(`HTML fragment path is not a regular file: ${htmlFragmentPath}`)
+        return null
+      }
+      return fs.readFileSync(htmlFragmentPath, 'utf8')
+    } catch {
+      this.context.logger.error(`HTML fragment file not found or unreadable: ${htmlFragmentPath}`)
+      return null
+    }
+  }
+
   /** The function configures the express app to serve the presentation */
   private configure() {
     const app = this.app
@@ -122,35 +156,8 @@ export class RevealServer extends Disposable {
       if (req.path !== '/') {
         next()
       } else {
-        let init: string | null = null
-        let initModule = false
-        let htmlFragmentContent: string | null = null
-        if (context.dirname) {
-          const initModulePath = path.join(context.dirname, 'init.esm.js')
-          const initPath = path.join(context.dirname, 'init.js')
-          if (fs.existsSync(initModulePath)) {
-            init = 'init.esm.js'
-            initModule = true
-          } else if (fs.existsSync(initPath)) {
-            init = fs.readFileSync(initPath, 'utf8')
-          }
-
-          const configuredFragmentPath = context.configuration.htmlFragment
-          const htmlFragmentPath = context.resolvePresentationFilePath(configuredFragmentPath)
-          if (configuredFragmentPath && !htmlFragmentPath) {
-            context.logger.error(`HTML fragment path must stay inside the presentation directory: ${configuredFragmentPath}`)
-          } else if (htmlFragmentPath) {
-            try {
-              if (!fs.statSync(htmlFragmentPath).isFile()) {
-                context.logger.error(`HTML fragment path is not a regular file: ${htmlFragmentPath}`)
-              } else {
-                htmlFragmentContent = fs.readFileSync(htmlFragmentPath, 'utf8')
-              }
-            } catch {
-              context.logger.error(`HTML fragment file not found or unreadable: ${htmlFragmentPath}`)
-            }
-          }
-        }
+        const { init, initModule } = this.loadInitScript()
+        const htmlFragmentContent = this.loadHtmlFragmentContent()
 
         setDiagramRenderingConfig({
           enabled: context.configuration.diagramServerEnabled,

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -118,10 +118,16 @@ export class RevealServer extends Disposable {
         next()
       } else {
         let init: string | null = null
+        let htmlFragment: string | null = null
         if (context.dirname) {
           const initPath = path.join(context.dirname, 'init.js')
           if (fs.existsSync(initPath)) {
             init = fs.readFileSync(initPath, 'utf8')
+          }
+
+          const htmlFragmentPath = context.resolveLocalAssetPath(context.configuration.htmlFragment)
+          if (htmlFragmentPath && fs.existsSync(htmlFragmentPath)) {
+            htmlFragment = fs.readFileSync(htmlFragmentPath, 'utf8')
           }
         }
 
@@ -135,7 +141,7 @@ export class RevealServer extends Disposable {
           html: markdownit.render(s.text),
           children: s.verticalChildren.map((c) => ({ ...c, html: markdownit.render(c.text) })),
         }))
-        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init })
+        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init, htmlFragment })
       }
     })
 

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -253,6 +253,24 @@ describe('RevealServer', () => {
     }
   })
 
+  test('injects configured local HTML fragment from markdown folder', async () => {
+    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-'))
+    const fragmentPath = path.join(dirname, 'fragment.html')
+    await fs.writeFile(fragmentPath, '<video id="background-video" src="intro.mp4"></video>')
+    const context = createContext({ dirname, configuration: { htmlFragment: 'fragment.html' } })
+    const server = new RevealServer(context)
+    try {
+      const response = await request(server.app).get('/')
+
+      expect(response.status).toEqual(200)
+      expect(response.text).toContain('<video id="background-video" src="intro.mp4"></video>')
+    } finally {
+      server.dispose()
+      context.dispose()
+      await fs.rm(dirname, { recursive: true, force: true })
+    }
+  })
+
   test('export middleware calls onExportError when exporter fails', async () => {
     const onExportError = jest.fn()
     const context = createContext({ inExport: true, onExportError })

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,6 +6,7 @@
 <body>
 
   <%- include('logo'); %>
+  <%- htmlFragment || '' %>
 
   <div class="reveal">
 


### PR DESCRIPTION
## Summary
- Add `revealjs.htmlFragment` as a local fragment path resolved relative to the markdown file.
- Read and inject the fragment into the rendered presentation body.
- Track the fragment as a referenced local asset so edits refresh the presentation.
- Add a server regression test for local fragment injection.

## Root cause
There was no supported configuration hook for injecting deck-wide HTML outside slide markdown. Users had to inline custom HTML in slides or maintain a separate Reveal.js setup for page-level elements such as a global background video.

## Validation
- `npm test -- --runInBand src/test/UnitTests/RevealServer.jest.ts -t "HTML fragment"`
- `npm test -- --runInBand src/test/UnitTests/Configuration.jest.ts src/test/UnitTests/RevealContext.jest.ts`
- `npm run test-compile`
- `npm test -- --runInBand`

Fixes #772