### PR TITLE
Quality: Conflicting commented-out configuration in jest.config.js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,24 +16,3 @@ module.exports = {
     '^open$': '<rootDir>/src/__mocks__/open.ts',
   },
 }
-
-// "jest": {
-//   "verbose": true,
-//   "preset": "ts-jest",
-//   "testMatch": [
-//     "**/*.jest.ts"
-//   ],
-//   "coverageReporters": [
-//     "lcov",
-//     "text"
-//   ],
-//   "collectCoverageFrom": [
-//     "**/src/**/*.ts",
-//     "!**/node_modules/**",
-//     "!**/vendor/**"
-//   ],
-//   "reporters": [
-//     "default",
-//     "jest-junit"
-//   ]
-// },


### PR DESCRIPTION
## Summary

Quality: Conflicting commented-out configuration in jest.config.js

## Problem

**Severity**: `Medium` | **File**: `jest.config.js:L38`

The jest.config.js file contains commented-out configuration at the bottom (lines 38-52) that creates confusion about the actual configuration state. This dead code should be removed to improve maintainability.

## Solution

Remove the commented-out jest configuration block at the bottom of the file

## Changes

- `jest.config.js` (modified)