### PR TITLE
ci: make extension releases safe by default

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,11 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
+      dryRun:
+        description: Build and verify the VSIX without publishing it
+        type: boolean
+        required: true
+        default: true
       publishMS:
         description: Publish to VS Marketplace
         type: boolean
@@ -116,6 +121,15 @@ jobs:
       - name: Create VSIX package
         run: npx @vscode/vsce package --no-dependencies --out "${{ needs.validate.outputs.package_name }}"
 
+      - name: Verify packaged extension contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          unzip -l "${{ needs.validate.outputs.package_name }}" > vsix-contents.txt
+          grep -q 'extension/package.json' vsix-contents.txt
+          grep -q 'extension/dist/extension.js' vsix-contents.txt
+          grep -q 'extension/CHANGELOG.md' vsix-contents.txt
+
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
         with:
@@ -126,7 +140,7 @@ jobs:
     name: Publish to VS Marketplace
     runs-on: ubuntu-latest
     needs: [validate, package]
-    if: github.event.inputs.publishMS == 'true'
+    if: github.event.inputs.dryRun == 'false' && github.event.inputs.publishMS == 'true'
     environment: visual-studio-marketplace
     steps:
       - uses: actions/download-artifact@v4
@@ -143,7 +157,7 @@ jobs:
     name: Publish to OpenVSX
     runs-on: ubuntu-latest
     needs: [validate, package]
-    if: github.event.inputs.publishOVSX == 'true'
+    if: github.event.inputs.dryRun == 'false' && github.event.inputs.publishOVSX == 'true'
     environment: open-vsx
     steps:
       - uses: actions/download-artifact@v4
@@ -160,7 +174,7 @@ jobs:
     name: Publish to GitHub Releases
     runs-on: ubuntu-latest
     needs: [validate, package]
-    if: github.event.inputs.publishGH == 'true'
+    if: github.event.inputs.dryRun == 'false' && github.event.inputs.publishGH == 'true'
     environment: github-releases
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Release process
+- Added a safe-by-default release dry run, VSIX content verification, and a maintainer release checklist.
+
 ### Changed
 - Updated dependencies to latest compatible versions
   - Express 5.0.1 → 5.1.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,13 +6,12 @@ The release workflow publishes one VSIX artifact to GitHub Releases, the Visual 
 
 1. Triage or explicitly defer open security and compatibility pull requests.
 2. Move the relevant entries under `Unreleased` in `CHANGELOG.md` to a section matching the intended semantic version.
-3. Set the same version in `package.json` and `package-lock.json`.
+3. Run `npm version <version> --no-git-tag-version` to update the version in both `package.json` and `package-lock.json` consistently.
 4. Run:
 
    ```bash
    npm ci
    npm run coverage
-   npm run vscode:prepublish
    npx @vscode/vsce package --no-dependencies
    ```
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,45 @@
+# Releasing vscode-reveal
+
+The release workflow publishes one VSIX artifact to GitHub Releases, the Visual Studio Marketplace, and Open VSX. It defaults to a dry run so maintainers can inspect the exact artifact before any registry is changed.
+
+## 1. Prepare the release
+
+1. Triage or explicitly defer open security and compatibility pull requests.
+2. Move the relevant entries under `Unreleased` in `CHANGELOG.md` to a section matching the intended semantic version.
+3. Set the same version in `package.json` and `package-lock.json`.
+4. Run:
+
+   ```bash
+   npm ci
+   npm run coverage
+   npm run vscode:prepublish
+   npx @vscode/vsce package --no-dependencies
+   ```
+
+5. Install the VSIX in a clean supported VS Code profile and verify preview, browser launch, HTML export, and the PDF flow with `sample.md`.
+
+## 2. Run the safe dry run
+
+Dispatch the **Release** workflow with `dryRun` enabled. The workflow builds the production bundle, creates the VSIX, verifies that it contains the extension manifest, bundle, and changelog, and uploads it as an artifact. It does not contact a registry.
+
+Download and inspect that artifact before continuing. The version must not already have a `release/<version>` tag.
+
+## 3. Publish the verified artifact
+
+Dispatch the workflow again with `dryRun` disabled. Keep all three publish targets enabled unless a registry is intentionally being recovered independently:
+
+- Visual Studio Marketplace
+- Open VSX
+- GitHub Releases
+
+The protected GitHub environments should require a maintainer approval and hold their own publishing token.
+
+## 4. Verify publication
+
+Confirm that the same version is visible in all three locations and that a fresh installation works:
+
+- `https://marketplace.visualstudio.com/items?itemName=evilz.vscode-reveal`
+- `https://open-vsx.org/extension/evilz/vscode-reveal`
+- `https://github.com/evilz/vscode-reveal/releases`
+
+If one registry fails, rerun only that target with the others disabled. Never rebuild or modify the VSIX between registry publications for the same version.


### PR DESCRIPTION
## What

- makes manual releases dry-run by default
- gates marketplace and GitHub publication behind an explicit opt-in
- verifies the VSIX payload before publishing
- documents the release and rollback procedure

## Why

The extension has not shipped since 2022. A guarded, reproducible release path reduces the risk of publishing an incomplete package while maintenance resumes.

## Checks

- `npm ci`
- `npm test` — 115 tests passed
- `npm run build`
- VSIX package created and inspected successfully

## Impact

No runtime behavior changes. Maintainers must explicitly disable dry-run to publish.
