### PR TITLE
Support ESM custom init scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ In this mode, diagram code blocks are kept as plain code blocks and no remote di
 
 ## Custom initialization
 
-Place an `init.js` file next to your markdown file to replace the default Reveal.js initialization script. If your initialization needs ECMAScript modules, use `init.esm.js` instead; it is loaded as `<script type="module">`, so it can use standard `import` statements for files served from the same folder. When both files exist, `init.esm.js` takes precedence.
+Place an `init.js` file next to your markdown file to replace the default Reveal.js initialization script. If your initialization needs ECMAScript modules, use `init.esm.js` instead; it is loaded as `<script type="module">`, so it can use standard `import` statements for files served from the same folder. When both files exist, `init.esm.js` takes precedence. `init.esm.js` must be a complete custom initialization script and initialize Reveal itself, just like `init.js`.
 
 ## <a id="options"></a> Reveal.js Options
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ diagramServerEnabled: false
 
 In this mode, diagram code blocks are kept as plain code blocks and no remote diagram request is made.
 
+## Custom initialization
+
+Place an `init.js` file next to your markdown file to replace the default Reveal.js initialization script. If your initialization needs ECMAScript modules, use `init.esm.js` instead; it is loaded as `<script type="module">`, so it can use standard `import` statements for files served from the same folder. When both files exist, `init.esm.js` takes precedence.
+
 ## <a id="options"></a> Reveal.js Options
 
 

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -30,7 +30,7 @@ export class RevealContext extends Disposable {
     public getConfiguration: () => Configuration,
     public extensionPath: string,
     public isInExport: () => boolean,
-    public onExportError: (error: unknown) => void = () => {}
+    public onExportError: (error: unknown) => void = () => {},
   ) {
     super()
     this.editor = editor
@@ -61,9 +61,7 @@ export class RevealContext extends Disposable {
   }
 
   public get exportPath(): string {
-    return path.isAbsolute(this.configuration.exportHTMLPath)
-      ? this.configuration.exportHTMLPath
-      : path.join(this.dirname, this.configuration.exportHTMLPath)
+    return path.isAbsolute(this.configuration.exportHTMLPath) ? this.configuration.exportHTMLPath : path.join(this.dirname, this.configuration.exportHTMLPath)
   }
 
   public resolveLocalAssetPath(assetPath: string | null | undefined, appendCssIfMissing = false): string | null {
@@ -84,6 +82,7 @@ export class RevealContext extends Disposable {
   public getReferencedAssetPaths(): string[] {
     const paths = new Set<string>()
     paths.add(path.join(this.dirname, 'init.js'))
+    paths.add(path.join(this.dirname, 'init.esm.js'))
 
     const customThemePath = this.resolveLocalAssetPath(this.configuration.customTheme, true)
     if (customThemePath) {
@@ -121,9 +120,7 @@ export class RevealContext extends Disposable {
     const { slides } = slideParser.parse(this.getText(range), this.configuration, false)
     const currentSlide = slides[slides.length - 1]
 
-    this.position = currentSlide.verticalChildren
-      ? { horizontal: slides.length - 1, vertical: currentSlide.verticalChildren.length }
-      : { horizontal: slides.length - 1, vertical: 0 }
+    this.position = currentSlide.verticalChildren ? { horizontal: slides.length - 1, vertical: currentSlide.verticalChildren.length } : { horizontal: slides.length - 1, vertical: 0 }
   }
 
   is(document: TextDocument) {
@@ -131,8 +128,7 @@ export class RevealContext extends Disposable {
   }
 
   goToSlide(topindex: number, verticalIndex: number) {
-    const linesCount =
-      countLinesToSlide(this.slides, topindex, verticalIndex) + (this.frontmatter?.frontmatter ? this.frontmatter.bodyBegin : 0)
+    const linesCount = countLinesToSlide(this.slides, topindex, verticalIndex) + (this.frontmatter?.frontmatter ? this.frontmatter.bodyBegin : 0)
 
     const position = new Position(linesCount, 0)
     this.editor.selection = new Selection(position, position) //selections = [new Selection(position, position)]
@@ -182,7 +178,7 @@ export class RevealContexts {
     private readonly isInExport: () => boolean,
     private readonly onExportError: (error: unknown) => void,
     private readonly onServerStart: (uri: string, context: RevealContext) => void,
-    private readonly onServerStop: (context: RevealContext) => void
+    private readonly onServerStop: (context: RevealContext) => void,
   ) {
     this.logger = logger
   }

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -118,9 +118,14 @@ export class RevealServer extends Disposable {
         next()
       } else {
         let init: string | null = null
+        let initModule = false
         if (context.dirname) {
+          const initModulePath = path.join(context.dirname, 'init.esm.js')
           const initPath = path.join(context.dirname, 'init.js')
-          if (fs.existsSync(initPath)) {
+          if (fs.existsSync(initModulePath)) {
+            init = 'init.esm.js'
+            initModule = true
+          } else if (fs.existsSync(initPath)) {
             init = fs.readFileSync(initPath, 'utf8')
           }
         }
@@ -135,7 +140,7 @@ export class RevealServer extends Disposable {
           html: markdownit.render(s.text),
           children: s.verticalChildren.map((c) => ({ ...c, html: markdownit.render(c.text) })),
         }))
-        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init })
+        res.render('index', { slides: htmlSlides, ...context.configuration, rootUrl: this.uri, init, initModule })
       }
     })
 

--- a/src/test/UnitTests/RevealContext.jest.ts
+++ b/src/test/UnitTests/RevealContext.jest.ts
@@ -37,18 +37,27 @@ jest.mock('../../utils', () => ({
 
 jest.mock('vscode', () => {
   class Position {
-    constructor(public line: number, public character: number) { }
+    constructor(
+      public line: number,
+      public character: number,
+    ) {}
     translate(deltaLine: number, deltaCharacter = 0) {
       return new Position(this.line + deltaLine, this.character + deltaCharacter)
     }
   }
 
   class Range {
-    constructor(public start: Position, public end: Position) { }
+    constructor(
+      public start: Position,
+      public end: Position,
+    ) {}
   }
 
   class Selection {
-    constructor(public anchor: Position, public active: Position) { }
+    constructor(
+      public anchor: Position,
+      public active: Position,
+    ) {}
   }
 
   class EventEmitter<T> {
@@ -61,7 +70,7 @@ jest.mock('vscode', () => {
     fire(event: T) {
       this.listener?.(event)
     }
-    dispose() { }
+    dispose() {}
   }
 
   return { Position, Range, Selection, EventEmitter }
@@ -94,7 +103,13 @@ describe('RevealContext', () => {
 
   test('computes asset paths and uri helpers', () => {
     const editor = makeEditor()
-    const context = new RevealContext(editor as any, logger as any, () => ({ ...defaultConfiguration, exportHTMLPath: 'dist' }), '/ext', () => false)
+    const context = new RevealContext(
+      editor as any,
+      logger as any,
+      () => ({ ...defaultConfiguration, exportHTMLPath: 'dist' }),
+      '/ext',
+      () => false,
+    )
     const slidesDir = path.dirname(editor.document.fileName)
 
     expect(context.dirname).toBe(slidesDir)
@@ -120,16 +135,18 @@ describe('RevealContext', () => {
       css: ['a.css', ' ', 'http://cdn/style.css', 'a.css', 'data:text/plain,hello'],
     }
 
-    expect(context.getReferencedAssetPaths()).toEqual([
-      path.join(slidesDir, 'init.js'),
-      path.resolve(slidesDir, 'styles', 'site.css'),
-      path.resolve(slidesDir, 'a.css'),
-    ])
+    expect(context.getReferencedAssetPaths()).toEqual([path.join(slidesDir, 'init.js'), path.join(slidesDir, 'init.esm.js'), path.resolve(slidesDir, 'styles', 'site.css'), path.resolve(slidesDir, 'a.css')])
   })
 
   test('refresh updates configuration, updates position, goToSlide and lifecycle methods', () => {
     const editor = makeEditor()
-    const context = new RevealContext(editor as any, logger as any, () => ({ ...defaultConfiguration, logLevel: LogLevel.Warning }), '/ext', () => false)
+    const context = new RevealContext(
+      editor as any,
+      logger as any,
+      () => ({ ...defaultConfiguration, logLevel: LogLevel.Warning }),
+      '/ext',
+      () => false,
+    )
 
     parseMock
       .mockReturnValueOnce({
@@ -184,7 +201,15 @@ describe('RevealContext', () => {
 describe('RevealContexts', () => {
   test('adds, reuses and removes contexts', () => {
     const logger = { info: jest.fn(), debug: jest.fn(), LogLevel: LogLevel.Error }
-    const contexts = new RevealContexts(logger as any, () => defaultConfiguration, '/ext', () => false, () => {}, () => {}, () => {})
+    const contexts = new RevealContexts(
+      logger as any,
+      () => defaultConfiguration,
+      '/ext',
+      () => false,
+      () => {},
+      () => {},
+      () => {},
+    )
 
     const editor = {
       document: {

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -12,12 +12,7 @@ import * as os from 'os'
 const localAssetPattern = /(?:href|src)="(libs\/[^"]+)"/g
 const collectLocalAssets = (html: string) => [...html.matchAll(localAssetPattern)].map((match) => match[1])
 
-const createContext = (options?: {
-  inExport?: boolean
-  dirname?: string
-  onExportError?: (error: unknown) => void
-  configuration?: Partial<Configuration> & Record<string, unknown>
-}) => {
+const createContext = (options?: { inExport?: boolean; dirname?: string; onExportError?: (error: unknown) => void; configuration?: Partial<Configuration> & Record<string, unknown> }) => {
   const logger = new Logger(() => undefined, LogLevel.Error)
   const inExport = options?.inExport ?? false
   const fileName = path.join(options?.dirname ?? os.tmpdir(), 'deck.md')
@@ -277,6 +272,25 @@ describe('RevealServer', () => {
     }
   })
 
+  test('loads init.esm.js as a module when present in markdown folder', async () => {
+    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-'))
+    const initPath = path.join(dirname, 'init.esm.js')
+    await fs.writeFile(initPath, 'import "./plugin.js";')
+    const context = createContext({ dirname })
+    const server = new RevealServer(context)
+    try {
+      const response = await request(server.app).get('/')
+
+      expect(response.status).toEqual(200)
+      expect(response.text).toContain('<script type="module" src="init.esm.js"></script>')
+      expect(response.text).not.toContain('import "./plugin.js";')
+    } finally {
+      server.dispose()
+      context.dispose()
+      await fs.rm(dirname, { recursive: true, force: true })
+    }
+  })
+
   test('export middleware calls onExportError when exporter fails', async () => {
     const onExportError = jest.fn()
     const context = createContext({ inExport: true, onExportError })
@@ -284,11 +298,7 @@ describe('RevealServer', () => {
     const exporter = jest.fn(async () => {
       throw new Error('boom')
     })
-    const middleware = (server as any).exportMiddleware(exporter, () => true) as (
-      req: any,
-      res: any,
-      next: () => void
-    ) => Promise<void>
+    const middleware = (server as any).exportMiddleware(exporter, () => true) as (req: any, res: any, next: () => void) => Promise<void>
     const next = jest.fn()
     const req = { originalUrl: '/index.html?x=1' }
     const res = {

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -256,37 +256,62 @@ describe('RevealServer', () => {
 
   test('loads init.js content when present in markdown folder', async () => {
     const dirname = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-'))
-    const initPath = path.join(dirname, 'init.js')
-    await fs.writeFile(initPath, 'window.testInitLoaded = true;')
-    const context = createContext({ dirname })
-    const server = new RevealServer(context)
+    let context: RevealContext | undefined
+    let server: RevealServer | undefined
     try {
+      const initPath = path.join(dirname, 'init.js')
+      await fs.writeFile(initPath, 'window.testInitLoaded = true;')
+      context = createContext({ dirname })
+      server = new RevealServer(context)
       const response = await request(server.app).get('/')
 
       expect(response.status).toEqual(200)
       expect(response.text).toContain('window.testInitLoaded = true;')
     } finally {
-      server.dispose()
-      context.dispose()
+      server?.dispose()
+      context?.dispose()
       await fs.rm(dirname, { recursive: true, force: true })
     }
   })
 
   test('loads init.esm.js as a module when present in markdown folder', async () => {
     const dirname = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-'))
-    const initPath = path.join(dirname, 'init.esm.js')
-    await fs.writeFile(initPath, 'import "./plugin.js";')
-    const context = createContext({ dirname })
-    const server = new RevealServer(context)
+    let context: RevealContext | undefined
+    let server: RevealServer | undefined
     try {
+      const initPath = path.join(dirname, 'init.esm.js')
+      await fs.writeFile(initPath, 'import "./plugin.js";')
+      context = createContext({ dirname })
+      server = new RevealServer(context)
       const response = await request(server.app).get('/')
 
       expect(response.status).toEqual(200)
       expect(response.text).toContain('<script type="module" src="init.esm.js"></script>')
       expect(response.text).not.toContain('import "./plugin.js";')
     } finally {
-      server.dispose()
-      context.dispose()
+      server?.dispose()
+      context?.dispose()
+      await fs.rm(dirname, { recursive: true, force: true })
+    }
+  })
+
+  test('prefers init.esm.js over init.js when both are present', async () => {
+    const dirname = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-'))
+    let context: RevealContext | undefined
+    let server: RevealServer | undefined
+    try {
+      await fs.writeFile(path.join(dirname, 'init.js'), 'window.legacyInitLoaded = true;')
+      await fs.writeFile(path.join(dirname, 'init.esm.js'), 'import "./plugin.js";')
+      context = createContext({ dirname })
+      server = new RevealServer(context)
+      const response = await request(server.app).get('/')
+
+      expect(response.status).toEqual(200)
+      expect(response.text).toContain('<script type="module" src="init.esm.js"></script>')
+      expect(response.text).not.toContain('window.legacyInitLoaded = true;')
+    } finally {
+      server?.dispose()
+      context?.dispose()
       await fs.rm(dirname, { recursive: true, force: true })
     }
   })

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -1,4 +1,6 @@
-<% if(init) { %>
+<% if(init && initModule) { %>
+<script type="module" src="<%= init %>"></script>
+<%}else if(init) { %>
 <script>
   <%- init %>
 </script>


### PR DESCRIPTION
### Motivation
- Allow users to provide an ECMAScript module initialization file next to their markdown deck so they can use `import`/ESM for custom Reveal initialization. 
- Keep backward compatibility with the existing `init.js` behavior while preferring an ESM entry when both exist. 

### Description
- Detect `init.esm.js` next to the markdown file and, if present, render it in the page as `<script type="module" src="init.esm.js"></script>` instead of inlining `init.js` content. 
- Preserve existing behaviour for `init.js` when `init.esm.js` is absent. 
- Add `init.esm.js` to the set of referenced asset paths so export/watch tooling will include it. 
- Update `views/init.ejs`, `src/RevealServer.ts`, `src/RevealContext.ts`, and unit tests to cover the new module-loading behaviour, and add documentation to `README.md` explaining `init.esm.js` precedence and use. 

### Testing
- Ran `npm run test-compile` successfully to ensure TypeScript compiles. 
- Ran `npm test -- --runTestsByPath src/test/UnitTests/RevealServer.jest.ts src/test/UnitTests/RevealContext.jest.ts` and all tests passed. 
- Attempted `npm run lint -- <files>` but it could not run in this environment because ESLint v10 requires a repository `eslint.config.*` file which is absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d23d2c5c0832cb9cab585b2a5d52b)