### PR TITLE
fix: use MathJax 2 when printing

### DIFF
--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -115,9 +115,10 @@ describe('RevealServer', () => {
     const server = new RevealServer(context)
 
     const response = await request(server.app).get('/')
+    const printPluginsBlock = response.text.match(/const printPlugins = \[([\s\S]*?)\]\.filter\(Boolean\);/)?.[1] ?? ''
 
-    expect(response.text).toContain('window.RevealMath,')
-    expect(response.text).not.toContain('window.RevealMath?.MathJax3')
+    expect(printPluginsBlock).toContain('window.RevealMath,')
+    expect(printPluginsBlock).not.toContain('window.RevealMath?.MathJax3')
 
     server.dispose()
     context.dispose()

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -110,6 +110,19 @@ describe('RevealServer', () => {
     context.dispose()
   })
 
+  test('uses the configured MathJax 2 plugin when printing', async () => {
+    const context = createContext()
+    const server = new RevealServer(context)
+
+    const response = await request(server.app).get('/')
+
+    expect(response.text).toContain('window.RevealMath,')
+    expect(response.text).not.toContain('window.RevealMath?.MathJax3')
+
+    server.dispose()
+    context.dispose()
+  })
+
   test('root request includes default-enabled optional plugin assets and registrations', async () => {
     const context = createContext()
     const server = new RevealServer(context)

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -17,7 +17,7 @@
       window.RevealLoadContent,
       window.RevealNotes,
       window.RevealHighlight,
-      window.RevealMath?.MathJax3,
+      window.RevealMath,
       window.RevealAnimate,
       window.RevealChart,
       <% if(enableChalkboard) {%>window.RevealChalkboard,<%}%>


### PR DESCRIPTION
## Summary
- use the configured Reveal MathJax 2 plugin for print-mode rendering
- avoid the MathJax 3 initialization that caused slow slide transitions
- add a regression test for the rendered print plugin list

Fixes #1068.

## Validation
- `npm test -- --runInBand src/test/UnitTests/RevealServer.jest.ts`
- `npm run lint`
- `npm run compile`