### PR TITLE
feat: support incremental list fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Fragments can be authored directly in markdown with attributes (no raw HTML need
 Paragraph shown later {.fragment .fade-up}
 ```
 
+To reveal every list item incrementally, set `revealjs.incremental` to `true` in VS Code settings or use `incremental: true` in a deck's front matter.
+
 If you need a sample file you can get it here:
 https://raw.githubusercontent.com/evilz/vscode-reveal/master/sample.md
 

--- a/package.json
+++ b/package.json
@@ -338,6 +338,11 @@
           "default": true,
           "description": "Turns fragments on and off globally"
         },
+        "revealjs.incremental": {
+          "type": "boolean",
+          "default": false,
+          "description": "Reveal list items one at a time as fragments"
+        },
         "revealjs.embedded": {
           "type": "boolean",
           "default": false,

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -46,6 +46,7 @@ export interface IRevealOptions {
   rtl: boolean
   shuffle: boolean
   fragments: boolean
+  incremental: boolean
   embedded: boolean
   help: boolean
   showNotes: boolean
@@ -141,6 +142,7 @@ export const defaultConfiguration: Configuration = {
   rtl: false,
   shuffle: false,
   fragments: true,
+  incremental: false,
   embedded: false,
   help: true,
   showNotes: false,

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -139,7 +139,8 @@ describe('RevealServer', () => {
   })
 
   test('treats non-boolean incremental settings as disabled', async () => {
-    const context = createContext({ configuration: { incremental: 'false;alert(1)//' } })
+    const configuration = { incremental: 'false;alert(1)//' } as unknown as Partial<Configuration> & Record<string, unknown>
+    const context = createContext({ configuration })
     const server = new RevealServer(context)
 
     const response = await request(server.app).get('/')

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -131,7 +131,21 @@ describe('RevealServer', () => {
     const response = await request(server.app).get('/')
 
     expect(response.text).toContain('const incremental = true;')
-    expect(response.text).toContain("document.querySelectorAll('.slides li').forEach((item) => item.classList.add('fragment'));")
+    expect(response.text).toContain("document.querySelectorAll('.slides li')")
+    expect(response.text).toContain("item.classList.add('fragment')")
+
+    server.dispose()
+    context.dispose()
+  })
+
+  test('treats non-boolean incremental settings as disabled', async () => {
+    const context = createContext({ configuration: { incremental: 'false;alert(1)//' } })
+    const server = new RevealServer(context)
+
+    const response = await request(server.app).get('/')
+
+    expect(response.text).toContain('const incremental = false;')
+    expect(response.text).not.toContain('alert(1)')
 
     server.dispose()
     context.dispose()

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -124,6 +124,19 @@ describe('RevealServer', () => {
     context.dispose()
   })
 
+  test('adds fragments to list items when incremental lists are enabled', async () => {
+    const context = createContext({ configuration: { incremental: true } })
+    const server = new RevealServer(context)
+
+    const response = await request(server.app).get('/')
+
+    expect(response.text).toContain('const incremental = true;')
+    expect(response.text).toContain("document.querySelectorAll('.slides li').forEach((item) => item.classList.add('fragment'));")
+
+    server.dispose()
+    context.dispose()
+  })
+
   test('root request includes default-enabled optional plugin assets and registrations', async () => {
     const context = createContext()
     const server = new RevealServer(context)

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -8,7 +8,7 @@
 
 <script>
   const loadedPlugins = (...plugins) => [...new Set(plugins.filter(Boolean))];
-  const incremental = <%= incremental %>;
+  const incremental = <%- jsonForScript(incremental === true) %>;
   if (incremental) {
     document.querySelectorAll('.slides li').forEach((item) => item.classList.add('fragment'));
   }

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -8,6 +8,10 @@
 
 <script>
   const loadedPlugins = (...plugins) => [...new Set(plugins.filter(Boolean))];
+  const incremental = <%= incremental %>;
+  if (incremental) {
+    document.querySelectorAll('.slides li').forEach((item) => item.classList.add('fragment'));
+  }
   const hasSeminarConfig = <%= typeof seminar !== 'undefined' && seminar && seminar.server && seminar.hash ? 'true' : 'false' %>;
   const seminarPlugins = hasSeminarConfig
     ? loadedPlugins(window.RevealSeminar, window.RevealPoll, window.RevealQnA)


### PR DESCRIPTION
## Summary
- add the opt-in `revealjs.incremental` setting
- add Reveal fragment classes to list items before initialization
- document the setting and add rendering coverage

Fixes #911.

## Validation
- `npm test -- --runInBand src/test/UnitTests/RevealServer.jest.ts src/test/UnitTests/Configuration.jest.ts`
- `npm run lint`
- `npm run compile`