### PR TITLE
fix: restore code focus support

### DIFF
--- a/libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js
+++ b/libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js
@@ -51,9 +51,9 @@
       }
 
       // Highlight code using highlight.js.
-      if (typeof hljs.highlightElement === 'function') {
+      if (!element.dataset.highlighted && hljs && typeof hljs.highlightElement === 'function') {
         hljs.highlightElement(element)
-      } else {
+      } else if (!element.dataset.highlighted && hljs) {
         hljs.highlightBlock(element)
       }
 

--- a/libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js
+++ b/libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js
@@ -51,7 +51,11 @@
       }
 
       // Highlight code using highlight.js.
-      hljs.highlightBlock(element)
+      if (typeof hljs.highlightElement === 'function') {
+        hljs.highlightElement(element)
+      } else {
+        hljs.highlightBlock(element)
+      }
 
       // Split highlighted code into lines.
       var openTags = [],

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -80,9 +80,8 @@ describe('RevealServer', () => {
     const missingAssets = localAssets.filter((asset) => !fsSync.existsSync(path.join(process.cwd(), asset)))
 
     expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/markdown.js')
-    expect(response.text).toContain('libs/highlight.js/11.3.1/highlight.min.js')
     expect(response.text).toContain('libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js')
-    expect(response.text).toContain('window.RevealCodeFocus?.();')
+    expect(response.text).toContain('.then(() => window.RevealCodeFocus?.());')
     expect(response.text).not.toContain('libs/reveal.js/6.0.1/plugin/markdown/markdown.js')
     expect(response.text).not.toContain('maxcdn.bootstrapcdn.com/font-awesome')
     expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/menu/font-awesome/css/all.css')
@@ -342,7 +341,6 @@ describe('RevealServer', () => {
       '/libs/reveal.js/6.0.1/plugin/loadcontent/plugin.js',
       '/libs/reveal.js/6.0.1/plugin/fullscreen/plugin.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3/d3.v3.min.js',
-      '/libs/highlight.js/11.3.1/highlight.min.js',
       '/libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3.patch.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3/queue.v1.min.js',

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -80,6 +80,9 @@ describe('RevealServer', () => {
     const missingAssets = localAssets.filter((asset) => !fsSync.existsSync(path.join(process.cwd(), asset)))
 
     expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/markdown.js')
+    expect(response.text).toContain('libs/highlight.js/11.3.1/highlight.min.js')
+    expect(response.text).toContain('libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js')
+    expect(response.text).toContain('window.RevealCodeFocus?.();')
     expect(response.text).not.toContain('libs/reveal.js/6.0.1/plugin/markdown/markdown.js')
     expect(response.text).not.toContain('maxcdn.bootstrapcdn.com/font-awesome')
     expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/menu/font-awesome/css/all.css')
@@ -339,6 +342,8 @@ describe('RevealServer', () => {
       '/libs/reveal.js/6.0.1/plugin/loadcontent/plugin.js',
       '/libs/reveal.js/6.0.1/plugin/fullscreen/plugin.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3/d3.v3.min.js',
+      '/libs/highlight.js/11.3.1/highlight.min.js',
+      '/libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3.patch.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3/queue.v1.min.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3/topojson.v1.min.js',

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -210,9 +210,7 @@
 					],
 			// Learn about plugins: https://revealjs.com/plugins/
 			plugins: (window.location.search.match(/print-pdf/gi) ? printPlugins : plugins ) 
-		});
-
-    window.RevealCodeFocus?.();
+		}).then(() => window.RevealCodeFocus?.());
 			
 
 

--- a/views/init.ejs
+++ b/views/init.ejs
@@ -211,6 +211,8 @@
 			// Learn about plugins: https://revealjs.com/plugins/
 			plugins: (window.location.search.match(/print-pdf/gi) ? printPlugins : plugins ) 
 		});
+
+    window.RevealCodeFocus?.();
 			
 
 

--- a/views/libs.ejs
+++ b/views/libs.ejs
@@ -2,7 +2,6 @@
 <script src="libs/reveal.js/6.0.1/plugin/notes.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/markdown.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/highlight.js"></script>
-<script src="libs/highlight.js/11.3.1/highlight.min.js"></script>
 <script src="libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/math.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/loadcontent/plugin.js"></script>

--- a/views/libs.ejs
+++ b/views/libs.ejs
@@ -2,6 +2,8 @@
 <script src="libs/reveal.js/6.0.1/plugin/notes.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/markdown.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/highlight.js"></script>
+<script src="libs/highlight.js/11.3.1/highlight.min.js"></script>
+<script src="libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/math.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/loadcontent/plugin.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/fullscreen/plugin.js"></script>


### PR DESCRIPTION
## Summary
- load and initialize the bundled code-focus integration
- adapt it to Highlight.js 11 while retaining its legacy fallback
- verify rendered assets and initialization with server tests

Fixes #865.

## Validation
- `npm test -- --runInBand src/test/UnitTests/RevealServer.jest.ts`
- `npm run lint`
- `npm run compile`