### PR TITLE
feat: highlight SPARQL and Turtle

### DIFF
--- a/libs/reveal.js/6.0.1/plugin/vscode-reveal-languages.js
+++ b/libs/reveal.js/6.0.1/plugin/vscode-reveal-languages.js
@@ -1,0 +1,42 @@
+(() => {
+  const hljs = window.RevealHighlight?.().hljs
+  if (!hljs) return
+
+  hljs.registerLanguage('sparql', () => ({
+    name: 'SPARQL',
+    aliases: ['rq'],
+    case_insensitive: true,
+    keywords: {
+      keyword: 'BASE PREFIX SELECT CONSTRUCT DESCRIBE ASK FROM NAMED WHERE ORDER BY GROUP HAVING LIMIT OFFSET DISTINCT REDUCED AS BIND VALUES INSERT DELETE DATA LOAD CLEAR CREATE DROP COPY MOVE ADD WITH USING DEFAULT GRAPH SILENT OPTIONAL UNION FILTER EXISTS NOT IN MINUS SERVICE BINDINGS',
+      literal: 'true false',
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.QUOTE_STRING_MODE,
+      hljs.APOS_STRING_MODE,
+      { className: 'variable', begin: /[?$][A-Za-z_][\w-]*/ },
+      { className: 'symbol', begin: /<[^<>\s]*>/ },
+      { className: 'number', begin: /[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[Ee][+-]?\d+)?/ },
+    ],
+  }))
+
+  hljs.registerLanguage('turtle', () => ({
+    name: 'Turtle',
+    aliases: ['ttl'],
+    case_insensitive: true,
+    keywords: {
+      keyword: '@prefix @base PREFIX BASE a',
+      literal: 'true false',
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.QUOTE_STRING_MODE,
+      hljs.APOS_STRING_MODE,
+      { className: 'meta', begin: /@(prefix|base)\b/i, end: /\./, excludeEnd: true },
+      { className: 'symbol', begin: /<[^<>\s]*>/ },
+      { className: 'symbol', begin: /(?:[A-Za-z][\w-]*)?:[\w.-]*/ },
+      { className: 'number', begin: /[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[Ee][+-]?\d+)?/ },
+    ],
+  }))
+})()

--- a/src/test/UnitTests/HighlightLanguages.jest.ts
+++ b/src/test/UnitTests/HighlightLanguages.jest.ts
@@ -1,0 +1,30 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import * as vm from 'vm'
+
+const workspaceRoot = path.resolve(__dirname, '../../..')
+const languagesPath = path.join(workspaceRoot, 'libs/reveal.js/6.0.1/plugin/vscode-reveal-languages.js')
+
+describe('additional Highlight.js languages', () => {
+  test('registers SPARQL and Turtle grammars with the bundled Reveal highlighter API', () => {
+    type Language = { name: string; aliases: string[]; keywords: { keyword: string }; contains: unknown[] }
+    const languages = new Map<string, (api: unknown) => Language>()
+    const highlighter = {
+      registerLanguage: (name: string, definition: (api: unknown) => Language) => languages.set(name, definition),
+    }
+    const window = { RevealHighlight: () => ({ hljs: highlighter }) }
+    vm.runInNewContext(fs.readFileSync(languagesPath, 'utf8'), { window })
+
+    expect(languages.get('sparql')).toBeDefined()
+    expect(languages.get('turtle')).toBeDefined()
+
+    const api = { C_LINE_COMMENT_MODE: {}, C_BLOCK_COMMENT_MODE: {}, QUOTE_STRING_MODE: {}, APOS_STRING_MODE: {} }
+    const sparql = languages.get('sparql')!(api)
+    const turtle = languages.get('turtle')!(api)
+
+    expect(sparql.aliases).toContain('rq')
+    expect(sparql.keywords.keyword).toContain('SELECT')
+    expect(turtle.aliases).toContain('ttl')
+    expect(turtle.keywords.keyword).toContain('@prefix')
+  })
+})

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -80,6 +80,7 @@ describe('RevealServer', () => {
     const missingAssets = localAssets.filter((asset) => !fsSync.existsSync(path.join(process.cwd(), asset)))
 
     expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/markdown.js')
+    expect(response.text).toContain('libs/reveal.js/6.0.1/plugin/vscode-reveal-languages.js')
     expect(response.text).toContain('libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js')
     expect(response.text).toContain('.then(() => window.RevealCodeFocus?.());')
     expect(response.text).not.toContain('libs/reveal.js/6.0.1/plugin/markdown/markdown.js')
@@ -342,6 +343,7 @@ describe('RevealServer', () => {
       '/libs/reveal.js/6.0.1/plugin/fullscreen/plugin.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3/d3.v3.min.js',
       '/libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js',
+      '/libs/reveal.js/6.0.1/plugin/vscode-reveal-languages.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3.patch.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3/queue.v1.min.js',
       '/libs/reveal.js/6.0.1/plugin/anything/d3/topojson.v1.min.js',

--- a/views/libs.ejs
+++ b/views/libs.ejs
@@ -2,6 +2,7 @@
 <script src="libs/reveal.js/6.0.1/plugin/notes.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/markdown.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/highlight.js"></script>
+<script src="libs/reveal.js/6.0.1/plugin/vscode-reveal-languages.js"></script>
 <script src="libs/highlight.js/9.15.10/reveal-code-focus-1.0.0-mod.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/math.js"></script>
 <script src="libs/reveal.js/6.0.1/plugin/loadcontent/plugin.js"></script>


### PR DESCRIPTION
## Summary
- register local SPARQL and Turtle grammars with the bundled Reveal Highlight.js plugin
- load the grammars before presentation initialization
- verify registration and static asset serving in unit tests

## Validation
- npm test -- --runInBand
- npm run test-compile
- npm run lint

Closes #1206
