### PR TITLE
fix: preload local export assets

### DIFF
--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -18,6 +18,21 @@ export const jsonForScript = (value: unknown): string => JSON.stringify(value)
 
 const isOfflineMode = (value: unknown): boolean => value === true || value === 'true'
 
+const localImageAssetPattern = /(?:src|data-background-image)=["']([^"']+)["']/gi
+const isExternalAsset = (asset: string): boolean => /^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(asset)
+
+const collectPreloadAssets = (slides: Array<{ html: string; attributes: string; children: Array<{ html: string; attributes: string }> }>): string[] => {
+  const assets = new Set<string>()
+  for (const slide of slides) {
+    const markup = [slide.html, slide.attributes, ...slide.children.flatMap((child) => [child.html, child.attributes])].join('\n')
+    for (const match of markup.matchAll(localImageAssetPattern)) {
+      const asset = match[1]?.trim()
+      if (asset && !isExternalAsset(asset)) assets.add(asset)
+    }
+  }
+  return [...assets]
+}
+
 /** Http server to serve reveal presentation */
 export class RevealServer extends Disposable {
   public readonly app = express()
@@ -175,7 +190,7 @@ export class RevealServer extends Disposable {
           html: markdownit.render(s.text),
           children: s.verticalChildren.map((c) => ({ ...c, html: markdownit.render(c.text) })),
         }))
-        res.render('index', { slides: htmlSlides, ...context.configuration, offline, rootUrl: this.uri, init, initModule, jsonForScript, htmlFragmentContent })
+        res.render('index', { slides: htmlSlides, preloadAssets: collectPreloadAssets(htmlSlides), ...context.configuration, offline, rootUrl: this.uri, init, initModule, jsonForScript, htmlFragmentContent })
       }
     })
 

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -18,16 +18,19 @@ export const jsonForScript = (value: unknown): string => JSON.stringify(value)
 
 const isOfflineMode = (value: unknown): boolean => value === true || value === 'true'
 
-const localImageAssetPattern = /(?:src|data-background-image)=["']([^"']+)["']/gi
+const imageSrcAssetPattern = /<img\b[^>]*\bsrc=["']([^"']+)["']/gi
+const backgroundImageAssetPattern = /\bdata-background-image=["']([^"']+)["']/gi
 const isExternalAsset = (asset: string): boolean => /^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(asset)
 
 const collectPreloadAssets = (slides: Array<{ html: string; attributes: string; children: Array<{ html: string; attributes: string }> }>): string[] => {
   const assets = new Set<string>()
   for (const slide of slides) {
     const markup = [slide.html, slide.attributes, ...slide.children.flatMap((child) => [child.html, child.attributes])].join('\n')
-    for (const match of markup.matchAll(localImageAssetPattern)) {
-      const asset = match[1]?.trim()
-      if (asset && !isExternalAsset(asset)) assets.add(asset)
+    for (const pattern of [imageSrcAssetPattern, backgroundImageAssetPattern]) {
+      for (const match of markup.matchAll(pattern)) {
+        const asset = match[1]?.trim()
+        if (asset && !isExternalAsset(asset)) assets.add(asset)
+      }
     }
   }
   return [...assets]
@@ -190,7 +193,7 @@ export class RevealServer extends Disposable {
           html: markdownit.render(s.text),
           children: s.verticalChildren.map((c) => ({ ...c, html: markdownit.render(c.text) })),
         }))
-        res.render('index', { slides: htmlSlides, preloadAssets: collectPreloadAssets(htmlSlides), ...context.configuration, offline, rootUrl: this.uri, init, initModule, jsonForScript, htmlFragmentContent })
+        res.render('index', { slides: htmlSlides, preloadAssets: context.isInExport() ? collectPreloadAssets(htmlSlides) : [], ...context.configuration, offline, rootUrl: this.uri, init, initModule, jsonForScript, htmlFragmentContent })
       }
     })
 

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -71,6 +71,27 @@ describe('RevealServer', () => {
     context.dispose()
   })
 
+  test('preloads local slide images and backgrounds so HTML export includes lazy-loaded assets', async () => {
+    const context = createContext()
+    context.slides = [{
+      title: 'Images',
+      index: 0,
+      text: '![Chart](images/chart.png)',
+      attributes: 'data-background-image="images/background.jpg"',
+      verticalChildren: [{ title: 'Child', index: 0, text: '![Remote](https://example.com/remote.png)', attributes: 'data-background-image="https://example.com/remote.jpg"', verticalChildren: [] }],
+    }]
+    const server = new RevealServer(context)
+
+    const response = await request(server.app).get('/')
+
+    expect(response.text).toContain('<link rel="preload" as="image" href="images/chart.png">')
+    expect(response.text).toContain('<link rel="preload" as="image" href="images/background.jpg">')
+    expect(response.text).not.toContain('rel="preload" as="image" href="https://example.com')
+
+    server.dispose()
+    context.dispose()
+  })
+
   test('root request references only bundled local assets', async () => {
     const context = createContext()
     const server = new RevealServer(context)

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -71,8 +71,9 @@ describe('RevealServer', () => {
     context.dispose()
   })
 
-  test('preloads local slide images and backgrounds so HTML export includes lazy-loaded assets', async () => {
-    const context = createContext()
+  test('preloads local slide images and backgrounds only while exporting', async () => {
+    const exportPath = await fs.mkdtemp(path.join(os.tmpdir(), tempDirectoryPrefix))
+    const context = createContext({ inExport: true, configuration: { exportHTMLPath: exportPath } })
     context.slides = [{
       title: 'Images',
       index: 0,
@@ -81,15 +82,17 @@ describe('RevealServer', () => {
       verticalChildren: [{ title: 'Child', index: 0, text: '![Remote](https://example.com/remote.png)', attributes: 'data-background-image="https://example.com/remote.jpg"', verticalChildren: [] }],
     }]
     const server = new RevealServer(context)
+    try {
+      const response = await request(server.app).get('/')
 
-    const response = await request(server.app).get('/')
-
-    expect(response.text).toContain('<link rel="preload" as="image" href="images/chart.png">')
-    expect(response.text).toContain('<link rel="preload" as="image" href="images/background.jpg">')
-    expect(response.text).not.toContain('rel="preload" as="image" href="https://example.com')
-
-    server.dispose()
-    context.dispose()
+      expect(response.text).toContain('<link rel="preload" as="image" href="images/chart.png">')
+      expect(response.text).toContain('<link rel="preload" as="image" href="images/background.jpg">')
+      expect(response.text).not.toContain('rel="preload" as="image" href="https://example.com')
+    } finally {
+      server.dispose()
+      context.dispose()
+      await fs.rm(exportPath, { recursive: true, force: true })
+    }
   })
 
   test('root request references only bundled local assets', async () => {

--- a/views/head.ejs
+++ b/views/head.ejs
@@ -11,6 +11,10 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+  <% preloadAssets.forEach(function(asset) { %>
+  <link rel="preload" as="image" href="<%= asset %>">
+  <% }) %>
+
   <link rel="stylesheet" href="libs/reveal.js/6.0.1/reset.css">
   <link rel="stylesheet" href="libs/reveal.js/6.0.1/reveal.css">
 


### PR DESCRIPTION
## Summary
- preload local slide images and background images during rendering
- ensure the export middleware receives lazy-loaded image assets
- leave remote presentation assets untouched

## Validation
- npm test -- --runInBand
- npm run test-compile
- npm run lint

Closes #879
