### PR TITLE
fix: sync Mermaid with dark Reveal themes

### DIFF
--- a/src/Markdown-it.ts
+++ b/src/Markdown-it.ts
@@ -25,11 +25,13 @@ const DEFAULT_DIAGRAM_SERVER = 'https://kroki.io'
 interface IDiagramRenderingConfig {
   enabled: boolean
   serverBaseUrl: string
+  mermaidTheme: 'dark' | null
 }
 
 const diagramRenderingConfig: IDiagramRenderingConfig = {
   enabled: true,
   serverBaseUrl: DEFAULT_DIAGRAM_SERVER,
+  mermaidTheme: null,
 }
 
 export const setDiagramRenderingConfig = (config: Partial<IDiagramRenderingConfig>) => {
@@ -41,6 +43,15 @@ export const setDiagramRenderingConfig = (config: Partial<IDiagramRenderingConfi
     const trimmedServerBaseUrl = config.serverBaseUrl.trim().replace(/\/$/, '')
     diagramRenderingConfig.serverBaseUrl = trimmedServerBaseUrl || DEFAULT_DIAGRAM_SERVER
   }
+
+  if (config.mermaidTheme === 'dark' || config.mermaidTheme === null) {
+    diagramRenderingConfig.mermaidTheme = config.mermaidTheme
+  }
+}
+
+const withMermaidTheme = (code: string): string => {
+  if (diagramRenderingConfig.mermaidTheme !== 'dark' || code.trimStart().startsWith('%%{')) return code
+  return `%%{init: {'theme':'dark'}}%%\n${code}`
 }
 
 const note = (markdown, config) => {
@@ -175,7 +186,8 @@ const markdown = md({
         return `<pre><code class="language-${lang.toLowerCase()}">${markdown.utils.escapeHtml(code)}</code></pre>`
       }
 
-      const data = Buffer.from(code, 'utf8')
+      const diagramCode = lang.toLowerCase() === 'mermaid' ? withMermaidTheme(code) : code
+      const data = Buffer.from(diagramCode, 'utf8')
       const compressed = pako.deflate(data, { level: 9 })
       const result = Buffer.from(compressed).toString('base64').replace(/\+/g, '-').replace(/\//g, '_')
       return `<pre style="all:unset;"><div><img class="${lang.toLowerCase()}" src="${diagramRenderingConfig.serverBaseUrl}/${lang.toLowerCase()}/svg/${result}" /></div></pre>`

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -17,6 +17,8 @@ export const jsonForScript = (value: unknown): string => JSON.stringify(value)
   .replace(/\u2029/g, '\\u2029')
 
 const isOfflineMode = (value: unknown): boolean => value === true || value === 'true'
+const darkRevealThemes = new Set(['black', 'blood', 'moon', 'night'])
+const getMermaidTheme = (theme: string): 'dark' | null => darkRevealThemes.has(theme) ? 'dark' : null
 
 const imageSrcAssetPattern = /<img\b[^>]*\bsrc=["']([^"']+)["']/gi
 const backgroundImageAssetPattern = /\bdata-background-image=["']([^"']+)["']/gi
@@ -186,6 +188,7 @@ export class RevealServer extends Disposable {
         setDiagramRenderingConfig({
           enabled: !offline && context.configuration.diagramServerEnabled,
           serverBaseUrl: context.configuration.diagramServerUrl,
+          mermaidTheme: getMermaidTheme(context.configuration.theme),
         })
 
         const htmlSlides = context.slides.map((s) => ({

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -17,7 +17,7 @@ export const jsonForScript = (value: unknown): string => JSON.stringify(value)
   .replace(/\u2029/g, '\\u2029')
 
 const isOfflineMode = (value: unknown): boolean => value === true || value === 'true'
-const darkRevealThemes = new Set(['black', 'blood', 'moon', 'night'])
+const darkRevealThemes = new Set(['black', 'blood', 'league', 'moon', 'night'])
 const getMermaidTheme = (theme: string): 'dark' | null => darkRevealThemes.has(theme) ? 'dark' : null
 
 const imageSrcAssetPattern = /<img\b[^>]*\bsrc=["']([^"']+)["']/gi

--- a/src/test/UnitTests/MarkdownItDiagramServer.jest.ts
+++ b/src/test/UnitTests/MarkdownItDiagramServer.jest.ts
@@ -1,8 +1,16 @@
 import markdownit, { setDiagramRenderingConfig } from '../../Markdown-it'
+import pako from 'pako'
+
+const getDiagramSource = (html: string): string => {
+  const encoded = html.match(/\/svg\/([^"']+)/)?.[1]
+  if (!encoded) throw new Error('Expected a Kroki diagram URL')
+  const compressed = Buffer.from(encoded.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+  return Buffer.from(pako.inflate(compressed)).toString('utf8')
+}
 
 describe('Markdown-it diagram server configuration', () => {
   afterEach(() => {
-    setDiagramRenderingConfig({ enabled: true, serverBaseUrl: 'https://kroki.io' })
+    setDiagramRenderingConfig({ enabled: true, serverBaseUrl: 'https://kroki.io', mermaidTheme: null })
   })
 
   test('uses the configured diagram server base URL', () => {
@@ -27,6 +35,16 @@ describe('Markdown-it diagram server configuration', () => {
     setDiagramRenderingConfig({ serverBaseUrl: '   ' })
     const html = markdownit.render('```mermaid\nflowchart LR\nA-->B\n```')
     expect(html).toContain('src="https://kroki.io/mermaid/svg/')
+  })
+
+  test('uses Mermaid dark mode for dark Reveal themes without overriding an author directive', () => {
+    setDiagramRenderingConfig({ mermaidTheme: 'dark' })
+
+    const themedHtml = markdownit.render('```mermaid\nflowchart LR\nA-->B\n```')
+    const explicitHtml = markdownit.render("```mermaid\n%%{init: {'theme':'forest'}}%%\nflowchart LR\nA-->B\n```")
+
+    expect(getDiagramSource(themedHtml)).toBe("%%{init: {'theme':'dark'}}%%\nflowchart LR\nA-->B\n")
+    expect(getDiagramSource(explicitHtml)).toBe("%%{init: {'theme':'forest'}}%%\nflowchart LR\nA-->B\n")
   })
 
   test('renders regular markdown syntax and speaker notes conversion', () => {

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -8,6 +8,7 @@ import * as path from 'path'
 import * as fs from 'fs/promises'
 import * as fsSync from 'fs'
 import * as os from 'os'
+import pako from 'pako'
 
 const localAssetPattern = /(?:href|src)="(libs\/[^"]+)"/g
 const collectLocalAssets = (html: string) => [...html.matchAll(localAssetPattern)].map((match) => match[1])
@@ -171,6 +172,21 @@ describe('RevealServer', () => {
     expect(response.text).toContain('!offlineMode && window.RevealMath,')
     expect(response.text).toContain('<pre><code class="language-mermaid">')
     expect(response.text).not.toContain('kroki.io/mermaid/svg/')
+
+    server.dispose()
+    context.dispose()
+  })
+
+  test('uses Mermaid dark mode with the default black Reveal theme', async () => {
+    const context = createContext()
+    context.slides = [{ title: 'Diagram', index: 0, text: '```mermaid\nflowchart LR\nA-->B\n```', verticalChildren: [], attributes: '' }]
+    const server = new RevealServer(context)
+
+    const response = await request(server.app).get('/')
+    const encoded = response.text.match(/mermaid\/svg\/([^"']+)/)?.[1]
+    const source = encoded ? Buffer.from(pako.inflate(Buffer.from(encoded.replace(/-/g, '+').replace(/_/g, '/'), 'base64'))).toString('utf8') : ''
+
+    expect(source).toContain("%%{init: {'theme':'dark'}}%%")
 
     server.dispose()
     context.dispose()

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -192,6 +192,21 @@ describe('RevealServer', () => {
     context.dispose()
   })
 
+  test('uses Mermaid dark mode with the league Reveal theme', async () => {
+    const context = createContext({ configuration: { theme: 'league' } })
+    context.slides = [{ title: 'Diagram', index: 0, text: '```mermaid\nflowchart LR\nA-->B\n```', verticalChildren: [], attributes: '' }]
+    const server = new RevealServer(context)
+
+    const response = await request(server.app).get('/')
+    const encoded = response.text.match(/mermaid\/svg\/([^"']+)/)?.[1]
+    const source = encoded ? Buffer.from(pako.inflate(Buffer.from(encoded.replace(/-/g, '+').replace(/_/g, '/'), 'base64'))).toString('utf8') : ''
+
+    expect(source).toContain("%%{init: {'theme':'dark'}}%%")
+
+    server.dispose()
+    context.dispose()
+  })
+
   test('treats a quoted false offline setting as online', async () => {
     const configuration = { offline: 'false' } as unknown as Partial<Configuration> & Record<string, unknown>
     const context = createContext({


### PR DESCRIPTION
## Summary
- apply Mermaid dark theming when a dark Reveal theme is active
- preserve author-provided Mermaid initialization directives
- cover encoded Kroki source and default Reveal rendering

## Validation
- npm test -- --runInBand
- npm run test-compile
- npm run lint

Closes #1193
