### PR TITLE
Add batch HTML export for Markdown folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,10 @@
         }
       },
       {
+        "command": "vscode-revealjs.exportHTMLFolder",
+        "title": "Revealjs: Export Markdown Folder to HTML"
+      },
+      {
         "command": "vscode-revealjs.showSample",
         "title": "Revealjs: Open a sample",
         "icon": {

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -27,6 +27,7 @@ import {
   TextDocumentChangeEvent,
   TextEditor,
   TextEditorSelectionChangeEvent,
+  Uri,
   workspace,
   ViewColumn,
   window,
@@ -44,6 +45,7 @@ import TextDecorator from './TextDecorator'
 import { RevealContext, RevealContexts } from './RevealContext'
 import { configPrefix, Configuration, ConfigurationDescription, getConfig } from './Configuration'
 import { collectDiagnostics } from './FrontmatterDiagnostics'
+import { getBatchExportPath } from './commands/exportHTMLFolder'
 
 const isMarkdownFile = (d: TextDocument) => d.languageId === 'markdown'
 
@@ -57,6 +59,7 @@ export default class MainController {
   private readonly assetWatchers = new Map<string, FileSystemWatcher>()
   private readonly diagnostics: DiagnosticCollection
   private readonly configByKey: Map<string, ConfigurationDescription>
+  private readonly extensionPath: string
 
   get baseUri() {
     return this.currentContext?.baseUri
@@ -131,6 +134,7 @@ export default class MainController {
     private config: Configuration,
     currentEditor: TextEditor | undefined
   ) {
+    this.extensionPath = extensionContext.extensionPath
     this.statusBarController = new StatusBarController()
     this.textDecorator = new TextDecorator(configDesc)
     this.revealContexts = new RevealContexts(
@@ -213,6 +217,46 @@ export default class MainController {
     }
 
     return promise
+  }
+
+  public exportFolderAsync = async (folder: Uri, files: readonly Uri[]) => {
+    const originalContext = this.currentContext
+    const exported: string[] = []
+
+    try {
+      for (const uri of files) {
+        const document = await workspace.openTextDocument(uri)
+        const context = this.createExportContext(document)
+        try {
+          context.refresh()
+          context.configuration.exportHTMLPath = getBatchExportPath(
+            folder.fsPath,
+            context.configuration.exportHTMLPath,
+            document.fileName,
+          )
+          this.currentContext = context
+
+          await this.exportAsync()
+          exported.push(context.exportPath)
+        } finally {
+          context.dispose()
+        }
+      }
+      return exported
+    } finally {
+      this.currentContext = originalContext
+      if (this.webViewPane && originalContext) this.refreshWebViewPane()
+    }
+  }
+
+  private createExportContext(document: TextDocument) {
+    const editor = {
+      document,
+      selection: new Position(0, 0),
+      selections: [],
+      revealRange: () => {},
+    } as unknown as TextEditor
+    return new RevealContext(editor, this.logger, () => this.config, this.extensionPath, this.isInExport, this.onExportError)
   }
 
   // debounce parse and refresh

--- a/src/commands/exportHTMLFolder.ts
+++ b/src/commands/exportHTMLFolder.ts
@@ -10,6 +10,9 @@ export const getBatchExportPath = (folderPath: string, configuredOutputPath: str
     ? configuredOutputPath
     : path.resolve(folderPath, configuredOutputPath)
   const relativePath = path.relative(folderPath, markdownPath)
+  if (relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw new Error('Markdown file must be inside the selected export folder.')
+  }
   const presentationPath = relativePath.replace(/\.md$/i, '')
 
   return path.join(outputRoot, presentationPath)

--- a/src/commands/exportHTMLFolder.ts
+++ b/src/commands/exportHTMLFolder.ts
@@ -1,0 +1,57 @@
+import path from 'path'
+import { ProgressLocation, RelativePattern, Uri, window, workspace } from 'vscode'
+import Logger from '../Logger'
+
+export const EXPORT_HTML_FOLDER = 'vscode-revealjs.exportHTMLFolder'
+export type EXPORT_HTML_FOLDER = typeof EXPORT_HTML_FOLDER
+
+export const getBatchExportPath = (folderPath: string, configuredOutputPath: string, markdownPath: string) => {
+  const outputRoot = path.isAbsolute(configuredOutputPath)
+    ? configuredOutputPath
+    : path.resolve(folderPath, configuredOutputPath)
+  const relativePath = path.relative(folderPath, markdownPath)
+  const presentationPath = relativePath.replace(/\.md$/i, '')
+
+  return path.join(outputRoot, presentationPath)
+}
+
+export const exportHTMLFolder = (
+  logger: Logger,
+  exportFiles: (folder: Uri, files: readonly Uri[]) => Promise<readonly string[]>,
+) => async (selectedFolder?: Uri) => {
+  const folder = selectedFolder ?? (await window.showOpenDialog({
+    canSelectFiles: false,
+    canSelectFolders: true,
+    canSelectMany: false,
+    openLabel: 'Export Markdown folder',
+  }))?.[0]
+
+  if (!folder) return
+
+  const files = await workspace.findFiles(
+    new RelativePattern(folder, '**/*.md'),
+    '**/{.git,node_modules}/**',
+  )
+  if (files.length === 0) {
+    void window.showWarningMessage('No Markdown files were found in the selected folder.')
+    return
+  }
+
+  try {
+    await window.withProgress(
+      { location: ProgressLocation.Notification, title: 'Export Markdown folder to HTML', cancellable: false },
+      async (progress) => {
+        progress.report({ message: `Exporting 0/${files.length}` })
+        const exported = await exportFiles(folder, files)
+        progress.report({ message: `Exported ${exported.length}/${files.length}` })
+        logger.info(`Exported ${exported.length} Markdown files from ${folder.fsPath}`)
+        void window.showInformationMessage(`Exported ${exported.length} Markdown presentations to HTML.`)
+      },
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error(`Folder export failed: ${message}`)
+    void window.showErrorMessage(`RevealJS folder HTML export failed: ${message}`)
+    throw error
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@
 
 import { commands, ExtensionContext, window, workspace } from 'vscode'
 import { EXPORT_HTML, exportHTML } from './commands/exportHTML'
+import { EXPORT_HTML_FOLDER, exportHTMLFolder } from './commands/exportHTMLFolder'
 import { EXPORT_PDF, exportPDF } from './commands/exportPDF'
 import { GO_TO_SLIDE } from './commands/goToSlide'
 import { SHOW_REVEALJS } from './commands/showRevealJS'
@@ -56,6 +57,7 @@ export function activate(context: ExtensionContext) {
     registerCmd(GO_TO_SLIDE, (arg) => main.goToSlide(arg.horizontal, arg.vertical)),
     registerCmd(EXPORT_PDF,exportPDF(() => main.currentContext?.startServer(), () => main.currentContext?.configuration.browserPath)),
     registerCmd(EXPORT_HTML,exportHTML(logger, main.exportAsync, main.shouldOpenFilemanagerAfterHTMLExport)),
+    registerCmd(EXPORT_HTML_FOLDER, exportHTMLFolder(logger, main.exportFolderAsync)),
 
     window.onDidChangeTextEditorSelection((e) => main.onDidChangeTextEditorSelection(e)),
     window.onDidChangeActiveTextEditor((e) => main.onDidChangeActiveTextEditor(e)),

--- a/src/test/UnitTests/MainController.jest.ts
+++ b/src/test/UnitTests/MainController.jest.ts
@@ -2,6 +2,7 @@ import MainController from '../../MainController'
 import Logger, { LogLevel } from '../../Logger'
 import { defaultConfiguration } from '../../Configuration'
 import { SHOW_REVEALJS } from '../../commands/showRevealJS'
+import path from 'path'
 
 const executeCommandMock = jest.fn()
 const diagnosticDeleteMock = jest.fn()
@@ -25,12 +26,19 @@ const createFileSystemWatcherMock = jest.fn(() => {
   return w
 })
 const createWebviewPanelMock = jest.fn(() => ({}))
+const openTextDocumentMock = jest.fn()
 
 jest.mock('vscode', () => ({
   commands: { executeCommand: (...args: unknown[]) => (executeCommandMock as any)(...args) },
   languages: { createDiagnosticCollection: (name: unknown) => (createDiagnosticCollectionMock as any)(name) },
-  workspace: { createFileSystemWatcher: (pattern: unknown, a: unknown, b: unknown, c: unknown) => (createFileSystemWatcherMock as any)(pattern, a, b, c) },
+  workspace: {
+    createFileSystemWatcher: (pattern: unknown, a: unknown, b: unknown, c: unknown) => (createFileSystemWatcherMock as any)(pattern, a, b, c),
+    openTextDocument: (uri: unknown) => (openTextDocumentMock as any)(uri),
+  },
   window: { createWebviewPanel: (viewType: unknown, title: unknown, column: unknown, options: unknown) => (createWebviewPanelMock as any)(viewType, title, column, options) },
+  Position: class Position {
+    constructor(public line: number, public character: number) {}
+  },
   RelativePattern: class RelativePattern {
     constructor(public base: string, public pattern: string) { }
   },
@@ -88,7 +96,20 @@ jest.mock('../../TextDecorator', () => jest.fn().mockImplementation(() => ({
 const revealContextsGetOrAddMock = jest.fn()
 const revealContextsRemoveMock = jest.fn()
 const revealContextsCtorMock = jest.fn()
+const temporaryContexts: Array<{ configuration: typeof defaultConfiguration; refresh: jest.Mock; dispose: jest.Mock; exportPath: string }> = []
 jest.mock('../../RevealContext', () => ({
+  RevealContext: jest.fn().mockImplementation(() => {
+    const context = {
+      configuration: { ...defaultConfiguration },
+      refresh: jest.fn(),
+      dispose: jest.fn(),
+      get exportPath() {
+        return this.configuration.exportHTMLPath
+      },
+    }
+    temporaryContexts.push(context)
+    return context
+  }),
   RevealContexts: jest.fn().mockImplementation((...args: unknown[]) => {
     revealContextsCtorMock(...args)
     return {
@@ -157,6 +178,7 @@ describe('MainController coverage', () => {
     jest.useFakeTimers()
     jest.clearAllMocks()
     watchers.length = 0
+    temporaryContexts.length = 0
     receiveMessageListener = undefined
     disposeListener = undefined
   })
@@ -308,6 +330,32 @@ describe('MainController coverage', () => {
     expect(executeCommandMock).toHaveBeenCalledWith(SHOW_REVEALJS)
     ;(main as any).onExportError(new Error('fail'))
     await expect(promise).rejects.toThrow('HTML export failed: fail')
+  })
+
+  test('exports a folder sequentially and restores the active context', async () => {
+    const originalContext = makeContext()
+    revealContextsGetOrAddMock.mockReturnValue(originalContext)
+    const main = new MainController(logger, { extensionPath: '/ext' } as any, [], defaultConfiguration, editor as any)
+    const folderPath = path.resolve('songs')
+    const files = [
+      { fsPath: path.join(folderPath, 'one.md') },
+      { fsPath: path.join(folderPath, 'set', 'two.md') },
+    ]
+    openTextDocumentMock
+      .mockResolvedValueOnce({ fileName: files[0].fsPath })
+      .mockResolvedValueOnce({ fileName: files[1].fsPath })
+    const exportAsyncSpy = jest.spyOn(main, 'exportAsync').mockResolvedValue('/ignored')
+
+    const exported = await main.exportFolderAsync({ fsPath: folderPath } as any, files as any)
+
+    expect(exportAsyncSpy).toHaveBeenCalledTimes(2)
+    expect(exported).toEqual([
+      path.join(folderPath, 'export', 'one'),
+      path.join(folderPath, 'export', 'set', 'two'),
+    ])
+    expect(temporaryContexts).toHaveLength(2)
+    expect(temporaryContexts.every((context) => context.refresh.mock.calls.length === 1 && context.dispose.mock.calls.length === 1)).toBe(true)
+    expect(main.currentContext).toBe(originalContext)
   })
 
   test('change and save document refresh when context matches, plus tree callback logging path', async () => {

--- a/src/test/UnitTests/exportHTMLFolder.jest.ts
+++ b/src/test/UnitTests/exportHTMLFolder.jest.ts
@@ -1,0 +1,67 @@
+const findFilesMock = jest.fn()
+const withProgressMock = jest.fn()
+const showInformationMessageMock = jest.fn()
+const showWarningMessageMock = jest.fn()
+const showErrorMessageMock = jest.fn()
+
+jest.mock('vscode', () => ({
+  ProgressLocation: { Notification: 15 },
+  RelativePattern: class RelativePattern {
+    constructor(public base: unknown, public pattern: string) {}
+  },
+  window: {
+    showOpenDialog: jest.fn(),
+    withProgress: (...args: unknown[]) => withProgressMock(...args),
+    showInformationMessage: (...args: unknown[]) => showInformationMessageMock(...args),
+    showWarningMessage: (...args: unknown[]) => showWarningMessageMock(...args),
+    showErrorMessage: (...args: unknown[]) => showErrorMessageMock(...args),
+  },
+  workspace: {
+    findFiles: (...args: unknown[]) => findFilesMock(...args),
+  },
+}))
+
+import Logger, { LogLevel } from '../../Logger'
+import { exportHTMLFolder, getBatchExportPath } from '../../commands/exportHTMLFolder'
+import path from 'path'
+
+describe('exportHTMLFolder command', () => {
+  const logger = new Logger(jest.fn(), LogLevel.Debug)
+  const folder = { fsPath: '/songs' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    withProgressMock.mockImplementation(async (_options, task) => task({ report: jest.fn() }))
+  })
+
+  test('keeps the Markdown folder hierarchy in the configured output directory', () => {
+    const folderPath = path.resolve('songs')
+    const absoluteOutputPath = path.resolve('reveal')
+
+    expect(getBatchExportPath(folderPath, './export', path.join(folderPath, 'set-one', 'intro.md'))).toBe(path.join(folderPath, 'export', 'set-one', 'intro'))
+    expect(getBatchExportPath(folderPath, absoluteOutputPath, path.join(folderPath, 'finale.md'))).toBe(path.join(absoluteOutputPath, 'finale'))
+  })
+
+  test('exports every Markdown file found below the selected folder', async () => {
+    const files = [{ fsPath: '/songs/one.md' }, { fsPath: '/songs/set/two.md' }]
+    findFilesMock.mockResolvedValue(files)
+    const exportFiles = jest.fn().mockResolvedValue(['/songs/export/one', '/songs/export/set/two'])
+
+    await exportHTMLFolder(logger, exportFiles)(folder as any)
+
+    expect(findFilesMock).toHaveBeenCalledWith(expect.anything(), '**/{.git,node_modules}/**')
+    expect(exportFiles).toHaveBeenCalledWith(folder, files)
+    expect(showInformationMessageMock).toHaveBeenCalledWith('Exported 2 Markdown presentations to HTML.')
+  })
+
+  test('reports an empty folder without starting an export', async () => {
+    findFilesMock.mockResolvedValue([])
+    const exportFiles = jest.fn()
+
+    await exportHTMLFolder(logger, exportFiles)(folder as any)
+
+    expect(exportFiles).not.toHaveBeenCalled()
+    expect(showWarningMessageMock).toHaveBeenCalledWith('No Markdown files were found in the selected folder.')
+    expect(showErrorMessageMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/test/UnitTests/exportHTMLFolder.jest.ts
+++ b/src/test/UnitTests/exportHTMLFolder.jest.ts
@@ -40,6 +40,7 @@ describe('exportHTMLFolder command', () => {
 
     expect(getBatchExportPath(folderPath, './export', path.join(folderPath, 'set-one', 'intro.md'))).toBe(path.join(folderPath, 'export', 'set-one', 'intro'))
     expect(getBatchExportPath(folderPath, absoluteOutputPath, path.join(folderPath, 'finale.md'))).toBe(path.join(absoluteOutputPath, 'finale'))
+    expect(() => getBatchExportPath(folderPath, './export', path.resolve(folderPath, '..', 'outside.md'))).toThrow('inside the selected export folder')
   })
 
   test('exports every Markdown file found below the selected folder', async () => {

--- a/src/test/UnitTests/extension.jest.ts
+++ b/src/test/UnitTests/extension.jest.ts
@@ -7,6 +7,7 @@ const NEW_PRESENTATION = 'test.newPresentation'
 const GO_TO_SLIDE = 'test.goToSlide'
 const EXPORT_PDF = 'test.exportPdf'
 const EXPORT_HTML = 'test.exportHtml'
+const EXPORT_HTML_FOLDER = 'test.exportHtmlFolder'
 
 const createOutputChannelMock = jest.fn(() => ({ appendLine: jest.fn() }))
 const executeCommandMock = jest.fn()
@@ -22,6 +23,7 @@ const showRevealJSInBrowserMock = jest.fn(() => jest.fn())
 const showRevealJSPresenterViewMock = jest.fn(() => jest.fn())
 const exportPDFMock = jest.fn(() => jest.fn())
 const exportHTMLMock = jest.fn(() => jest.fn())
+const exportHTMLFolderMock = jest.fn(() => jest.fn())
 const showSampleMock = jest.fn()
 const createPresentationFromTemplateMock = jest.fn()
 const languageCompletionMock = jest.fn(() => [{ dispose: jest.fn() }])
@@ -45,6 +47,7 @@ const mainControllerInstance = {
   onDidChangeConfiguration: jest.fn(),
   refresh: jest.fn(),
   exportAsync: jest.fn(),
+  exportFolderAsync: jest.fn(),
   shouldOpenFilemanagerAfterHTMLExport: jest.fn(() => true),
 }
 
@@ -96,6 +99,11 @@ jest.mock('../../commands/exportPDF', () => ({
 jest.mock('../../commands/exportHTML', () => ({
   EXPORT_HTML,
   exportHTML: (logger: unknown, exportAsync: unknown, shouldOpen: unknown) => (exportHTMLMock as any)(logger, exportAsync, shouldOpen),
+}))
+
+jest.mock('../../commands/exportHTMLFolder', () => ({
+  EXPORT_HTML_FOLDER,
+  exportHTMLFolder: (logger: unknown, exportFolder: unknown) => (exportHTMLFolderMock as any)(logger, exportFolder),
 }))
 
 jest.mock('../../commands/showSample', () => ({
@@ -164,6 +172,7 @@ describe('extension activate', () => {
     expect(registerCommandMock).toHaveBeenCalledWith(GO_TO_SLIDE, expect.any(Function))
     expect(registerCommandMock).toHaveBeenCalledWith(EXPORT_PDF, expect.any(Function))
     expect(registerCommandMock).toHaveBeenCalledWith(EXPORT_HTML, expect.any(Function))
+    expect(registerCommandMock).toHaveBeenCalledWith(EXPORT_HTML_FOLDER, expect.any(Function))
 
     jest.advanceTimersByTime(500)
     expect(mainControllerInstance.refresh).toHaveBeenCalledWith(0)


### PR DESCRIPTION
## What changed
- Add a command that recursively exports Markdown files in a selected folder to HTML.
- Preserve each document's relative directory path below the configured export output.
- Exclude .git and node_modules while reporting empty folders and successful batch counts.

## Validation
- npm test -- --runInBand
- npm run test-compile
- npm run lint

Closes #1318.