### PR TITLE
Dispose reveal resources deterministically

### DIFF
--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -341,7 +341,7 @@ export default class MainController extends Disposable {
       return false
     } else {
       const webviewPanel = window.createWebviewPanel('RevealJS', 'Reveal JS presentation', ViewColumn.Beside, { enableScripts: true })
-      this.webViewPane = this._register(new WebViewPane(webviewPanel))
+      this.webViewPane = new WebViewPane(webviewPanel)
       this._register(this.webViewPane.onDidReceiveMessage((message) => {
         if (!message || typeof message !== 'object') return
 
@@ -365,6 +365,7 @@ export default class MainController extends Disposable {
         this.logInfo('WebView', 'disposed')
         this.webViewPane = undefined
       }))
+      this._register(this.webViewPane)
       this.refreshWebViewPane()
       return true
     }

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -46,10 +46,11 @@ import { RevealContext, RevealContexts } from './RevealContext'
 import { configPrefix, Configuration, ConfigurationDescription, getConfig } from './Configuration'
 import { collectDiagnostics } from './FrontmatterDiagnostics'
 import { getBatchExportPath } from './commands/exportHTMLFolder'
+import { Disposable } from './dispose'
 
 const isMarkdownFile = (d: TextDocument) => d.languageId === 'markdown'
 
-export default class MainController {
+export default class MainController extends Disposable {
   private readonly statusBarController: StatusBarController
   private readonly slidesExplorer: SlideTreeProvider
   private readonly textDecorator: TextDecorator
@@ -108,13 +109,15 @@ export default class MainController {
   }
 
   public onDidCloseTextDocument(document: TextDocument) {
+    this.diagnostics.delete(document.uri)
+    this.revealContexts.remove(document.uri)
+
     if (this.currentContext?.is(document)) {
-      this.diagnostics.delete(document.uri)
       this.currentContext = undefined
-      this.revealContexts.remove(document.uri)
       this.syncAssetWatchers()
-      this.logger.debug(`onDidCloseTextDocument ${document.uri}`)
     }
+
+    this.logger.debug(`onDidCloseTextDocument ${document.uri}`)
   }
 
   public onDidChangeConfiguration(e: ConfigurationChangeEvent) {
@@ -134,10 +137,11 @@ export default class MainController {
     private config: Configuration,
     currentEditor: TextEditor | undefined
   ) {
+    super()
     this.extensionPath = extensionContext.extensionPath
-    this.statusBarController = new StatusBarController()
-    this.textDecorator = new TextDecorator(configDesc)
-    this.revealContexts = new RevealContexts(
+    this.statusBarController = this._register(new StatusBarController())
+    this.textDecorator = this._register(new TextDecorator(configDesc))
+    this.revealContexts = this._register(new RevealContexts(
       logger,
       () => this.config,
       extensionContext.extensionPath,
@@ -153,17 +157,17 @@ export default class MainController {
           this.statusBarController.updateServerInfo(null)
         }
       }
-    )
-    this.diagnostics = languages.createDiagnosticCollection('vscode-revealjs')
+    ))
+    this.diagnostics = this._register(languages.createDiagnosticCollection('vscode-revealjs'))
     this.configByKey = new Map(configDesc.map((d) => [d.label, d]))
 
     if (currentEditor && isMarkdownFile(currentEditor.document)) {
       this.currentContext = this.revealContexts.getOrAdd(currentEditor)
     }
 
-    this.slidesExplorer = new SlideTreeProvider(() => (this.currentContext ? this.currentContext.slides : []))
+    this.slidesExplorer = this._register(new SlideTreeProvider(() => (this.currentContext ? this.currentContext.slides : [])))
     this.slidesExplorer.register()
-    this.slidesExplorer.onDidChangeTreeData(() => this.logInfo(`SlideTreeProvider`, `updated`))
+    this._register(this.slidesExplorer.onDidChangeTreeData(() => this.logInfo(`SlideTreeProvider`, `updated`)))
   }
 
   //#region Log helpers
@@ -337,8 +341,8 @@ export default class MainController {
       return false
     } else {
       const webviewPanel = window.createWebviewPanel('RevealJS', 'Reveal JS presentation', ViewColumn.Beside, { enableScripts: true })
-      this.webViewPane = new WebViewPane(webviewPanel)
-      this.webViewPane.onDidReceiveMessage((message) => {
+      this.webViewPane = this._register(new WebViewPane(webviewPanel))
+      this._register(this.webViewPane.onDidReceiveMessage((message) => {
         if (!message || typeof message !== 'object') return
 
         const command = 'command' in message ? message.command : undefined
@@ -356,11 +360,11 @@ export default class MainController {
         const vertical = 'vertical' in message ? Number(message.vertical) : Number.NaN
         if (!Number.isFinite(horizontal) || !Number.isFinite(vertical)) return
         this.goToSlide(horizontal, vertical)
-      })
-      this.webViewPane.onDidDispose(() => {
+      }))
+      this._register(this.webViewPane.onDidDispose(() => {
         this.logInfo('WebView', 'disposed')
         this.webViewPane = undefined
-      })
+      }))
       this.refreshWebViewPane()
       return true
     }
@@ -382,5 +386,25 @@ export default class MainController {
   /** Stop server from listening */
   public stopServer() {
     this.currentContext?.stopServer()
+  }
+
+  public dispose() {
+    if (this.#refreshTimeout) {
+      clearTimeout(this.#refreshTimeout)
+      this.#refreshTimeout = null
+    }
+
+    for (const watcher of this.assetWatchers.values()) {
+      watcher.dispose()
+    }
+    this.assetWatchers.clear()
+
+    if (this.exportState) {
+      this.exportState.reject(new Error('HTML export was interrupted because the extension was disposed'))
+      this.exportState = null
+    }
+
+    this.currentContext = undefined
+    super.dispose()
   }
 }

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -233,7 +233,7 @@ export class RevealContext extends Disposable {
   }
 }
 
-export class RevealContexts {
+export class RevealContexts extends Disposable {
   private readonly innerMap = new Map<Uri, RevealContext>()
 
   constructor(
@@ -244,7 +244,9 @@ export class RevealContexts {
     private readonly onExportError: (error: unknown) => void,
     private readonly onServerStart: (uri: string, context: RevealContext) => void,
     private readonly onServerStop: (context: RevealContext) => void,
-  ) {}
+  ) {
+    super()
+  }
 
   getOrAdd(editor: TextEditor) {
     if (this.innerMap.has(editor.document.uri)) return this.innerMap.get(editor.document.uri)
@@ -264,5 +266,13 @@ export class RevealContexts {
       this.innerMap.delete(uri)
       context.dispose()
     }
+  }
+
+  dispose(): void {
+    for (const context of this.innerMap.values()) {
+      context.dispose()
+    }
+    this.innerMap.clear()
+    super.dispose()
   }
 }

--- a/src/SlideExplorer.ts
+++ b/src/SlideExplorer.ts
@@ -8,7 +8,7 @@ import { ISlide } from './ISlide'
 export class SlideTreeProvider extends Disposable
   implements vscode.TreeDataProvider<SlideNode>
 {
-  private readonly _onDidChangeTreeData: vscode.EventEmitter<SlideNode | null> = new vscode.EventEmitter<SlideNode | null>()
+  private readonly _onDidChangeTreeData = this._register(new vscode.EventEmitter<SlideNode | null>())
 
   public readonly onDidChangeTreeData: vscode.Event<SlideNode | null> = this._onDidChangeTreeData.event
 

--- a/src/TextDecorator.ts
+++ b/src/TextDecorator.ts
@@ -1,20 +1,21 @@
-import {DecorationOptions, MarkdownString, Range, TextEditor, ThemeColor, window} from 'vscode';
+import {DecorationOptions, MarkdownString, Range, TextEditor, TextEditorDecorationType, ThemeColor, window} from 'vscode';
 import { ConfigurationDescription } from './Configuration';
+import { Disposable } from './dispose';
 
 
 // styles for known options in the frontmatter
-const revealjsConfigKeyForeground = window.createTextEditorDecorationType({
-    fontWeight: 'bold',
-    fontStyle: 'italic',
-    color: new ThemeColor('revealjs.configKeyForeground'),
-  })
-  
-export default class TextDecorator {
+export default class TextDecorator extends Disposable {
 
     #propertiesRegex: RegExp
+    readonly #decorationType: TextEditorDecorationType
    
     constructor(private configDesc:ConfigurationDescription[] ) {
-        
+        super()
+        this.#decorationType = this._register(window.createTextEditorDecorationType({
+            fontWeight: 'bold',
+            fontStyle: 'italic',
+            color: new ThemeColor('revealjs.configKeyForeground'),
+        }))
         const allProps = configDesc.map(x => x.label).join('|')
         this.#propertiesRegex = new RegExp(`^(${allProps}):.*$`, 'gm');
     }
@@ -38,7 +39,7 @@ export default class TextDecorator {
 			decorations.push(decoration);
 		}
 
-        editor.setDecorations(revealjsConfigKeyForeground, decorations);
+        editor.setDecorations(this.#decorationType, decorations);
     }
 
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,8 @@ export function activate(context: ExtensionContext) {
   }
 
   context.subscriptions.push(
+    main,
+    outputChannel,
     registerCmd(SHOW_REVEALJS, () => main.showWebViewPane()  ),
     registerCmd(SHOW_REVEALJS_IN_BROWSER, showRevealJSInBrowser(() => main.currentContext?.startServer(), () => main.currentContext?.configuration.browserPath )),
     registerCmd(SHOW_REVEALJS_PRESENTER_VIEW, showRevealJSPresenterView(() => main.currentContext?.startServer(), () => main.currentContext?.configuration.browserPath)),
@@ -70,7 +72,8 @@ export function activate(context: ExtensionContext) {
   );
 
 
-  setTimeout(() => main.refresh(0),500)
+  const refreshTimer = setTimeout(() => main.refresh(0),500)
+  context.subscriptions.push({ dispose: () => clearTimeout(refreshTimer) })
 
 }
 

--- a/src/test/UnitTests/MainController.jest.ts
+++ b/src/test/UnitTests/MainController.jest.ts
@@ -68,6 +68,7 @@ const slideExplorerUpdateMock = jest.fn()
 const slideExplorerRegisterMock = jest.fn()
 const slideExplorerOnDidChangeTreeDataMock = jest.fn()
 const slideExplorerSlidesGetterMock = jest.fn()
+const slideExplorerDisposeMock = jest.fn()
 jest.mock('../../SlideExplorer', () => ({
   SlideTreeProvider: jest.fn().mockImplementation((slidesGetter: () => unknown[]) => {
     slideExplorerSlidesGetterMock.mockImplementation(slidesGetter)
@@ -75,26 +76,32 @@ jest.mock('../../SlideExplorer', () => ({
       register: slideExplorerRegisterMock,
       onDidChangeTreeData: slideExplorerOnDidChangeTreeDataMock,
       update: slideExplorerUpdateMock,
+      dispose: slideExplorerDisposeMock,
     }
   }),
 }))
 
 const statusBarUpdateCountMock = jest.fn()
 const statusBarUpdateServerInfoMock = jest.fn()
+const statusBarDisposeMock = jest.fn()
 jest.mock('../../StatusBarController', () => ({
   StatusBarController: jest.fn().mockImplementation(() => ({
     updateCount: statusBarUpdateCountMock,
     updateServerInfo: statusBarUpdateServerInfoMock,
+    dispose: statusBarDisposeMock,
   })),
 }))
 
 const textDecoratorUpdateMock = jest.fn()
+const textDecoratorDisposeMock = jest.fn()
 jest.mock('../../TextDecorator', () => jest.fn().mockImplementation(() => ({
   update: textDecoratorUpdateMock,
+  dispose: textDecoratorDisposeMock,
 })))
 
 const revealContextsGetOrAddMock = jest.fn()
 const revealContextsRemoveMock = jest.fn()
+const revealContextsDisposeMock = jest.fn()
 const revealContextsCtorMock = jest.fn()
 const temporaryContexts: Array<{ configuration: typeof defaultConfiguration; refresh: jest.Mock; dispose: jest.Mock; exportPath: string }> = []
 jest.mock('../../RevealContext', () => ({
@@ -115,6 +122,7 @@ jest.mock('../../RevealContext', () => ({
     return {
       getOrAdd: (...getArgs: unknown[]) => (revealContextsGetOrAddMock as any)(...getArgs),
       remove: (...removeArgs: unknown[]) => (revealContextsRemoveMock as any)(...removeArgs),
+      dispose: revealContextsDisposeMock,
     }
   }),
 }))
@@ -124,6 +132,7 @@ let disposeListener: (() => void) | undefined
 const webViewPaneUpdateMock = jest.fn(() => Promise.resolve())
 const webViewPaneCtorMock = jest.fn()
 const goToSlideFromPaneMock = jest.fn()
+const webViewPaneDisposeMock = jest.fn()
 
 jest.mock('../../WebViewPane', () => ({
   __esModule: true,
@@ -137,6 +146,7 @@ jest.mock('../../WebViewPane', () => ({
         disposeListener = cb
       },
       update: (uri: unknown, isExport: unknown) => (webViewPaneUpdateMock as any)(uri, isExport),
+      dispose: webViewPaneDisposeMock,
     }
     webViewPaneCtorMock()
     return pane
@@ -243,6 +253,42 @@ describe('MainController coverage', () => {
     expect(revealContextsRemoveMock).toHaveBeenCalledWith('doc-uri')
     expect(watchers[0].dispose).toHaveBeenCalled()
     expect(main.currentContext).toBeUndefined()
+  })
+
+  test('closing a non-current document disposes its context without clearing active state', () => {
+    const context = makeContext()
+    context.is.mockReturnValue(false)
+    revealContextsGetOrAddMock.mockReturnValue(context)
+    const main = new MainController(logger, { extensionPath: '/ext' } as any, [], defaultConfiguration, editor as any)
+    const otherDocument = { uri: 'other-doc-uri' }
+
+    main.onDidCloseTextDocument(otherDocument as any)
+
+    expect(diagnosticDeleteMock).toHaveBeenCalledWith('other-doc-uri')
+    expect(revealContextsRemoveMock).toHaveBeenCalledWith('other-doc-uri')
+    expect(main.currentContext).toBe(context)
+  })
+
+  test('dispose releases controller-owned resources and is idempotent', () => {
+    const context = makeContext()
+    revealContextsGetOrAddMock.mockReturnValue(context)
+    const main = new MainController(logger, { extensionPath: '/ext' } as any, [], defaultConfiguration, editor as any)
+
+    ;(main as any).syncAssetWatchers()
+    main.showWebViewPane()
+    main.refresh()
+    main.dispose()
+    main.dispose()
+
+    expect(watchers[0].dispose).toHaveBeenCalledTimes(1)
+    expect(revealContextsDisposeMock).toHaveBeenCalledTimes(1)
+    expect(createDiagnosticCollectionMock.mock.results[0].value.dispose).toHaveBeenCalledTimes(1)
+    expect(slideExplorerDisposeMock).toHaveBeenCalledTimes(1)
+    expect(statusBarDisposeMock).toHaveBeenCalledTimes(1)
+    expect(textDecoratorDisposeMock).toHaveBeenCalledTimes(1)
+    expect(webViewPaneDisposeMock).toHaveBeenCalledTimes(1)
+    expect(main.currentContext).toBeUndefined()
+    expect(context.refresh).not.toHaveBeenCalled()
   })
 
   test('showWebViewPane handles panel reuse and message events', async () => {

--- a/src/test/UnitTests/MainController.jest.ts
+++ b/src/test/UnitTests/MainController.jest.ts
@@ -146,7 +146,10 @@ jest.mock('../../WebViewPane', () => ({
         disposeListener = cb
       },
       update: (uri: unknown, isExport: unknown) => (webViewPaneUpdateMock as any)(uri, isExport),
-      dispose: webViewPaneDisposeMock,
+      dispose: () => {
+        webViewPaneDisposeMock()
+        disposeListener?.()
+      },
     }
     webViewPaneCtorMock()
     return pane
@@ -287,6 +290,7 @@ describe('MainController coverage', () => {
     expect(statusBarDisposeMock).toHaveBeenCalledTimes(1)
     expect(textDecoratorDisposeMock).toHaveBeenCalledTimes(1)
     expect(webViewPaneDisposeMock).toHaveBeenCalledTimes(1)
+    expect((main as any).webViewPane).toBeUndefined()
     expect(main.currentContext).toBeUndefined()
     expect(context.refresh).not.toHaveBeenCalled()
   })

--- a/src/test/UnitTests/RevealContext.jest.ts
+++ b/src/test/UnitTests/RevealContext.jest.ts
@@ -302,4 +302,38 @@ describe('RevealContexts', () => {
 
     contexts.remove('unknown-uri' as unknown as Uri)
   })
+
+  test('disposes every retained context and clears the collection', () => {
+    const logger = { info: jest.fn(), debug: jest.fn(), LogLevel: LogLevel.Error }
+    const contexts = new RevealContexts(
+      logger as unknown as Logger,
+      () => defaultConfiguration,
+      '/ext',
+      () => false,
+      () => {},
+      () => {},
+      () => {},
+    )
+    const makeContextEditor = (uri: string) => ({
+      document: {
+        fileName: `/workspace/slides/${uri}.md`,
+        uri: { scheme: 'file', toString: () => uri },
+        getText: jest.fn(() => ''),
+      },
+      revealRange: jest.fn(),
+    }) as unknown as TextEditor
+    const firstEditor = makeContextEditor('first')
+    const secondEditor = makeContextEditor('second')
+    const first = contexts.getOrAdd(firstEditor)!
+    const second = contexts.getOrAdd(secondEditor)!
+    const firstDispose = jest.spyOn(first, 'dispose')
+    const secondDispose = jest.spyOn(second, 'dispose')
+
+    contexts.dispose()
+    contexts.dispose()
+
+    expect(firstDispose).toHaveBeenCalledTimes(1)
+    expect(secondDispose).toHaveBeenCalledTimes(1)
+    expect((contexts as any).innerMap.size).toBe(0)
+  })
 })

--- a/src/test/UnitTests/extension.jest.ts
+++ b/src/test/UnitTests/extension.jest.ts
@@ -9,7 +9,8 @@ const EXPORT_PDF = 'test.exportPdf'
 const EXPORT_HTML = 'test.exportHtml'
 const EXPORT_HTML_FOLDER = 'test.exportHtmlFolder'
 
-const createOutputChannelMock = jest.fn(() => ({ appendLine: jest.fn() }))
+const outputChannelDisposeMock = jest.fn()
+const createOutputChannelMock = jest.fn(() => ({ appendLine: jest.fn(), dispose: outputChannelDisposeMock }))
 const executeCommandMock = jest.fn()
 const registerCommandMock = jest.fn((name: string, callback: (...args: unknown[]) => unknown) => ({ name, callback, dispose: jest.fn() }))
 const onDidChangeTextEditorSelectionMock = jest.fn(() => ({ dispose: jest.fn() }))
@@ -49,6 +50,7 @@ const mainControllerInstance = {
   exportAsync: jest.fn(),
   exportFolderAsync: jest.fn(),
   shouldOpenFilemanagerAfterHTMLExport: jest.fn(() => true),
+  dispose: jest.fn(),
 }
 
 const MainControllerMock = jest.fn(() => mainControllerInstance)
@@ -177,5 +179,7 @@ describe('extension activate', () => {
     jest.advanceTimersByTime(500)
     expect(mainControllerInstance.refresh).toHaveBeenCalledWith(0)
     expect((context as any).subscriptions.length).toBeGreaterThan(0)
+    expect((context as any).subscriptions).toContain(mainControllerInstance)
+    expect((context as any).subscriptions).toContain(createOutputChannelMock.mock.results[0].value)
   })
 })


### PR DESCRIPTION
## Summary
- dispose every tracked presentation context when its document closes or the extension shuts down
- make `MainController` own watchers, diagnostics, status UI, tree provider, decorator, webview, timers, and pending exports
- register the controller and output channel with the VS Code extension context
- add regression coverage for non-current document closure and idempotent cleanup

## Validation
- `npm test -- --runInBand`
- `npx tsc -p ./ --noEmit`
- `npm run lint -- --no-fix`
- `npm run build`
- `git diff --check`

Closes #1526