### PR TITLE
Add browser-compatible Reveal preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "onCommand:vscode-revealjs.newPresentation"
   ],
   "main": "./dist/extension.js",
+  "browser": "./dist/web/extension.js",
   "contributes": {
     "colors": [
       {
@@ -672,8 +673,9 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run -S esbuild-base -- --minify",
+    "vscode:prepublish": "npm run -S esbuild-base -- --minify && npm run -S esbuild-web -- --minify",
     "esbuild-base": "rimraf dist && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "esbuild-web": "esbuild ./src/web/extension.ts --bundle --outfile=dist/web/extension.js --external:vscode --format=cjs --platform=browser --target=es2020",
     "build": "npm run -S esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "watch": "npm run -S esbuild-base -- --sourcemap --watch",

--- a/src/test/UnitTests/WebExtension.jest.ts
+++ b/src/test/UnitTests/WebExtension.jest.ts
@@ -1,0 +1,21 @@
+jest.mock('vscode', () => ({}))
+
+import { createPresentationHtml, renderSlides } from '../../web/extension'
+
+describe('web extension preview', () => {
+  test('renders front matter and horizontal Markdown slides', () => {
+    const slides = renderSlides('---\ntitle: Demo\n---\n# First\n\n---\n## Second')
+
+    expect(slides).toContain('<h1>First</h1>')
+    expect(slides).toContain('<h2>Second</h2>')
+    expect(slides).not.toContain('title: Demo')
+  })
+
+  test('uses supplied webview URIs for Reveal assets and local document references', () => {
+    const html = createPresentationHtml('# Demo', (asset) => `webview://${asset}`, 'webview://workspace/slides')
+
+    expect(html).toContain('<base href="webview://workspace/slides/">')
+    expect(html).toContain('webview://libs/reveal.js/6.0.1/reveal.js')
+    expect(html).toContain('Reveal.initialize')
+  })
+})

--- a/src/test/UnitTests/WebExtension.jest.ts
+++ b/src/test/UnitTests/WebExtension.jest.ts
@@ -11,6 +11,14 @@ describe('web extension preview', () => {
     expect(slides).not.toContain('title: Demo')
   })
 
+  test('splits CRLF Markdown slide separators', () => {
+    const slides = renderSlides('# First\r\n---\r\n# Second')
+
+    expect(slides).toContain('<h1>First</h1>')
+    expect(slides).toContain('<h1>Second</h1>')
+    expect(slides.match(/<section>/g)).toHaveLength(2)
+  })
+
   test('uses supplied webview URIs for Reveal assets and local document references', () => {
     const html = createPresentationHtml('# Demo', (asset) => `webview://${asset}`, 'webview://workspace/slides')
 

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -2,6 +2,16 @@ import * as vscode from 'vscode'
 
 const SHOW_REVEALJS = 'vscode-revealjs.showRevealJS'
 const SHOW_REVEALJS_IN_BROWSER = 'vscode-revealjs.showRevealJSInBrowser'
+const unsupportedCommands = [
+  'vscode-revealjs.showRevealJSPresenterView',
+  'vscode-revealjs.stopRevealJSServer',
+  'vscode-revealjs.goToSlide',
+  'vscode-revealjs.exportPDF',
+  'vscode-revealjs.exportHTML',
+  'vscode-revealjs.exportHTMLFolder',
+  'vscode-revealjs.showSample',
+  'vscode-revealjs.newPresentation',
+]
 
 const escapeHtml = (value: string) => value
   .replace(/&/g, '&amp;')
@@ -23,7 +33,7 @@ const renderMarkdown = (markdown: string) => {
 
 export const renderSlides = (markdown: string) => markdown
   .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '')
-  .split(/^---$/gm)
+  .split(/^---\r?$/gm)
   .map((slide) => `<section>${renderMarkdown(slide)}</section>`)
   .join('\n')
 
@@ -70,8 +80,12 @@ const showPresentation = (context: vscode.ExtensionContext) => {
 }
 
 export const activate = (context: vscode.ExtensionContext) => {
+  const unsupported = () => {
+    void vscode.window.showErrorMessage('This Reveal.js command is not available in the VS Code web editor.')
+  }
   context.subscriptions.push(
     vscode.commands.registerCommand(SHOW_REVEALJS, () => showPresentation(context)),
     vscode.commands.registerCommand(SHOW_REVEALJS_IN_BROWSER, () => showPresentation(context)),
+    ...unsupportedCommands.map((command) => vscode.commands.registerCommand(command, unsupported)),
   )
 }

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode'
+
+const SHOW_REVEALJS = 'vscode-revealjs.showRevealJS'
+const SHOW_REVEALJS_IN_BROWSER = 'vscode-revealjs.showRevealJSInBrowser'
+
+const escapeHtml = (value: string) => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;')
+
+const renderMarkdown = (markdown: string) => {
+  const escaped = escapeHtml(markdown.trim())
+  return escaped
+    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/\n/g, '<br>')
+}
+
+export const renderSlides = (markdown: string) => markdown
+  .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '')
+  .split(/^---$/gm)
+  .map((slide) => `<section>${renderMarkdown(slide)}</section>`)
+  .join('\n')
+
+export const createPresentationHtml = (
+  markdown: string,
+  assetUri: (path: string) => string,
+  documentBaseUri: string,
+) => `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <base href="${documentBaseUri}/">
+  <link rel="stylesheet" href="${assetUri('libs/reveal.js/6.0.1/reset.css')}">
+  <link rel="stylesheet" href="${assetUri('libs/reveal.js/6.0.1/reveal.css')}">
+  <link rel="stylesheet" href="${assetUri('libs/reveal.js/6.0.1/theme/black.css')}">
+</head>
+<body>
+  <div class="reveal"><div class="slides">${renderSlides(markdown)}</div></div>
+  <script src="${assetUri('libs/reveal.js/6.0.1/reveal.js')}"></script>
+  <script>Reveal.initialize({ hash: true });</script>
+</body>
+</html>`
+
+const showPresentation = (context: vscode.ExtensionContext) => {
+  const editor = vscode.window.activeTextEditor
+  if (!editor || editor.document.languageId !== 'markdown') {
+    void vscode.window.showErrorMessage('Open a Markdown document to preview it with Reveal.js.')
+    return
+  }
+
+  const documentFolder = vscode.Uri.joinPath(editor.document.uri, '..')
+  const panel = vscode.window.createWebviewPanel(
+    'RevealJS',
+    'Reveal JS presentation',
+    vscode.ViewColumn.Beside,
+    {
+      enableScripts: true,
+      localResourceRoots: [context.extensionUri, documentFolder],
+    },
+  )
+  const assetUri = (assetPath: string) => panel.webview.asWebviewUri(vscode.Uri.joinPath(context.extensionUri, assetPath)).toString()
+  const documentBaseUri = panel.webview.asWebviewUri(documentFolder).toString().replace(/\/$/, '')
+  panel.webview.html = createPresentationHtml(editor.document.getText(), assetUri, documentBaseUri)
+}
+
+export const activate = (context: vscode.ExtensionContext) => {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(SHOW_REVEALJS, () => showPresentation(context)),
+    vscode.commands.registerCommand(SHOW_REVEALJS_IN_BROWSER, () => showPresentation(context)),
+  )
+}


### PR DESCRIPTION
## What changed
- Add a browser extension entry point for vscode.dev and github.dev.
- Render Markdown slides in a webview using bundled Reveal assets through webview resource URIs.
- Keep the existing Node extension entry point unchanged and build both targets during packaging.

## Validation
- npm test -- --runInBand
- npm run test-compile
- npm run esbuild-web
- npm run lint

Closes #1265.