### PR TITLE
Add self-contained HTML export

### DIFF
--- a/package.json
+++ b/package.json
@@ -527,6 +527,11 @@
           "default": true,
           "description": "Open the file manager after HTML export"
         },
+        "revealjs.selfContained": {
+          "type": "boolean",
+          "default": false,
+          "description": "Inline local export assets so HTML export produces one self-contained index.html file"
+        },
         "revealjs.enableMenu": {
           "type": "boolean",
           "default": true,

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -100,6 +100,7 @@ export interface IExtensionOptions {
   browserPath: string | null
   exportHTMLPath: string
   openFilemanagerAfterHTMLExport: boolean
+  selfContained: boolean
   logLevel: LogLevel
 }
 
@@ -177,6 +178,7 @@ export const defaultConfiguration: Configuration = {
   browserPath: null,
   exportHTMLPath: `./export`,
   openFilemanagerAfterHTMLExport: true,
+  selfContained: false,
   logLevel: LogLevel.Error,
 
   enableMenu: true,

--- a/src/ExportHTML.ts
+++ b/src/ExportHTML.ts
@@ -1,6 +1,50 @@
 
 import * as jetpack from "fs-jetpack";
 import * as path from 'path'
+import * as fs from 'fs/promises'
+
+const assetMimeTypes: Record<string, string> = {
+  '.css': 'text/css',
+  '.gif': 'image/gif',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.js': 'text/javascript',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+const isExternalReference = (value: string) => /^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(value)
+const dataUri = (data: Buffer, filePath: string) => `data:${assetMimeTypes[path.extname(filePath).toLowerCase()] ?? 'application/octet-stream'};base64,${data.toString('base64')}`
+
+const resolveLocalExportAsset = (folderPath: string, reference: string) => {
+  if (!reference || isExternalReference(reference)) return null
+  const pathname = reference.split(/[?#]/, 1)[0]
+  if (!pathname) return null
+  const resolvedPath = path.resolve(folderPath, pathname)
+  const relativePath = path.relative(folderPath, resolvedPath)
+  return relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath) ? null : resolvedPath
+}
+
+const inlineCssUrls = async (css: string, cssDirectory: string, exportFolderPath: string) => {
+  const matches = [...css.matchAll(/url\((['"]?)([^)'"\\]+)\1\)/gi)]
+  let result = css
+  for (const match of matches) {
+    const reference = match[2].trim()
+    if (!reference || isExternalReference(reference)) continue
+    const pathname = reference.split(/[?#]/, 1)[0]
+    const assetPath = pathname ? path.resolve(cssDirectory, pathname) : null
+    const relativePath = assetPath ? path.relative(exportFolderPath, assetPath) : '..'
+    if (!assetPath || relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) continue
+    try {
+      result = result.replace(match[0], `url(${dataUri(await fs.readFile(assetPath), assetPath)})`)
+    } catch {
+      // Keep a missing optional asset reference unchanged.
+    }
+  }
+  return result
+}
 
 export interface IExportOptions {
   folderPath: string,
@@ -21,4 +65,54 @@ export const exportHTML = async (options: IExportOptions) => {
   else if (srcFilePath) {
     await jetpack.copyAsync(srcFilePath, filePath, { overwrite: true })
   }
+}
+
+/**
+ * Replace local assets in an exported deck with data URIs so index.html can be
+ * distributed on its own. External URLs remain external by design.
+ */
+export const createSelfContainedExport = async (folderPath: string) => {
+  const indexPath = path.join(folderPath, 'index.html')
+  let html = await fs.readFile(indexPath, 'utf8')
+
+  // The extension-generated export has bounded script tags; attributes cannot contain unescaped quotes.
+  // eslint-disable-next-line sonarjs/slow-regex
+  const scriptMatches = [...html.matchAll(/<script([^>]*)\s+src=(['"])([^'"]+)\2([^>]*)><\/script>/gi)]
+  for (const match of scriptMatches) {
+    const assetPath = resolveLocalExportAsset(folderPath, match[3])
+    if (!assetPath) continue
+    try {
+      html = html.replace(match[0], `<script${match[1]}${match[4]}>${await fs.readFile(assetPath, 'utf8')}</script>`)
+    } catch {
+      // Keep external or unavailable scripts as their original references.
+    }
+  }
+
+  // The extension-generated export has bounded link tags; attributes cannot contain unescaped quotes.
+  // eslint-disable-next-line sonarjs/slow-regex
+  const stylesheetMatches = [...html.matchAll(/<link([^>]*)\s+href=(['"])([^'"]+)\2([^>]*)>/gi)]
+  for (const match of stylesheetMatches) {
+    if (!/\bstylesheet\b/i.test(match[1] + match[4])) continue
+    const assetPath = resolveLocalExportAsset(folderPath, match[3])
+    if (!assetPath) continue
+    try {
+      html = html.replace(match[0], `<style>${await inlineCssUrls(await fs.readFile(assetPath, 'utf8'), path.dirname(assetPath), folderPath)}</style>`)
+    } catch {
+      // Keep a missing optional stylesheet reference unchanged.
+    }
+  }
+
+  const resourceMatches = [...html.matchAll(/\s(src|href)=(['"])([^'"]+)\2/gi)]
+  for (const match of resourceMatches) {
+    const assetPath = resolveLocalExportAsset(folderPath, match[3])
+    if (!assetPath) continue
+    try {
+      html = html.replace(match[0], ` ${match[1]}=${match[2]}${dataUri(await fs.readFile(assetPath), assetPath)}${match[2]}`)
+    } catch {
+      // Keep a missing optional resource reference unchanged.
+    }
+  }
+
+  await fs.writeFile(indexPath, html)
+  await Promise.all((await fs.readdir(folderPath)).filter((entry) => entry !== 'index.html').map((entry) => fs.rm(path.join(folderPath, entry), { recursive: true, force: true })))
 }

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -47,6 +47,7 @@ import { configPrefix, Configuration, ConfigurationDescription, getConfig } from
 import { collectDiagnostics } from './FrontmatterDiagnostics'
 import { getBatchExportPath } from './commands/exportHTMLFolder'
 import { Disposable } from './dispose'
+import { createSelfContainedExport } from './ExportHTML'
 
 const isMarkdownFile = (d: TextDocument) => d.languageId === 'markdown'
 
@@ -183,6 +184,7 @@ export default class MainController extends Disposable {
     resolve: (path: string) => void
     reject: (error: Error) => void
     path: string
+    selfContained: boolean
   } | null = null
   public isInExport = () => this.exportState !== null
 
@@ -211,7 +213,7 @@ export default class MainController extends Disposable {
     const exportPath = this.currentContext.exportPath
 
     const promise = new Promise<string>((resolve, reject) => {
-      this.exportState = { resolve, reject, path: exportPath }
+      this.exportState = { resolve, reject, path: exportPath, selfContained: this.currentContext!.configuration.selfContained }
     })
 
     if (this.webViewPane) {
@@ -347,10 +349,7 @@ export default class MainController extends Disposable {
 
         const command = 'command' in message ? message.command : undefined
         if (command === 'exportComplete') {
-          if (this.exportState) {
-            this.exportState.resolve(this.exportState.path)
-            this.exportState = null
-          }
+          void this.completeExport()
           return
         }
 
@@ -368,6 +367,19 @@ export default class MainController extends Disposable {
       this._register(this.webViewPane)
       this.refreshWebViewPane()
       return true
+    }
+  }
+
+  private async completeExport() {
+    const exportState = this.exportState
+    if (!exportState) return
+    try {
+      if (exportState.selfContained) await createSelfContainedExport(exportState.path)
+      exportState.resolve(exportState.path)
+    } catch (error) {
+      exportState.reject(new Error(`HTML export failed: ${error instanceof Error ? error.message : String(error)}`))
+    } finally {
+      if (this.exportState === exportState) this.exportState = null
     }
   }
 

--- a/src/test/UnitTests/exportHTML.jest.ts
+++ b/src/test/UnitTests/exportHTML.jest.ts
@@ -1,3 +1,31 @@
+import * as fs from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
+import { createSelfContainedExport } from '../../ExportHTML'
+
+test('creates a single HTML export by inlining local scripts, styles, fonts and images', async () => {
+  const folder = await fs.mkdtemp(path.join(os.tmpdir(), 'vscode-reveal-single-'))
+  try {
+    await fs.mkdir(path.join(folder, 'assets'))
+    await fs.writeFile(path.join(folder, 'assets', 'app.js'), 'window.deckReady = true;')
+    await fs.writeFile(path.join(folder, 'assets', 'font.woff2'), Buffer.from([1, 2, 3]))
+    await fs.writeFile(path.join(folder, 'assets', 'logo.png'), Buffer.from([4, 5, 6]))
+    await fs.writeFile(path.join(folder, 'assets', 'deck.css'), '@font-face { src: url("font.woff2"); }')
+    await fs.writeFile(path.join(folder, 'index.html'), '<link rel="stylesheet" href="assets/deck.css"><script src="assets/app.js"></script><img src="assets/logo.png"><a href="https://example.com">external</a>')
+
+    await createSelfContainedExport(folder)
+
+    const html = await fs.readFile(path.join(folder, 'index.html'), 'utf8')
+    expect(html).toContain('<style>@font-face { src: url(data:font/woff2;base64,AQID); }</style>')
+    expect(html).toContain('<script>window.deckReady = true;</script>')
+    expect(html).toContain('src="data:image/png;base64,BAUG"')
+    expect(html).toContain('href="https://example.com"')
+    await expect(fs.readdir(folder)).resolves.toEqual(['index.html'])
+  } finally {
+    await fs.rm(folder, { recursive: true, force: true })
+  }
+})
+
 const withProgressMock = jest.fn()
 const showErrorMessageMock = jest.fn()
 


### PR DESCRIPTION
## Summary
- add revealjs.selfContained to fold local export assets into index.html
- inline scripts, styles, fonts, and image assets while retaining external URLs
- remove generated auxiliary files after finalization

## Validation
- npm test -- --runInBand
- npm run test-compile
- npm run lint

Closes #1017