### PR TITLE
Support persistent slide states

### DIFF
--- a/src/SlideParser.ts
+++ b/src/SlideParser.ts
@@ -40,13 +40,15 @@ const findTitle = (text: string) => {
   return lines[0] ?? ''
 }
 
-const persistentDataStateMarker = /\s*data-state-persistent(?:=(?:"true"|'true'|true))?/i
-const dataStateAttribute = /\bdata-state\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/i
+const persistentDataStateMarker = /(?:^|\s)data-state-persistent(?:\s*=\s*(\S+))?(?=\s|$)/i
+const dataStateAttribute = /(?:^|\s)data-state\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)(?=\s|$)/i
 
 const applyPersistentDataState = (slides: ISlide[]) => {
   let persistentState: string | null = null
   for (const slide of slides.flatMap((slide) => [slide, ...slide.verticalChildren])) {
-    const isPersistent = persistentDataStateMarker.test(slide.attributes)
+    const marker = persistentDataStateMarker.exec(slide.attributes)
+    const markerValue = marker?.[1]?.replace(/^['"]|['"]$/g, '').toLowerCase()
+    const isPersistent = Boolean(marker) && markerValue !== 'false'
     slide.attributes = slide.attributes.replace(persistentDataStateMarker, '').trim()
     const state = dataStateAttribute.exec(slide.attributes)?.[0] ?? null
     if (state && isPersistent) {

--- a/src/SlideParser.ts
+++ b/src/SlideParser.ts
@@ -40,6 +40,25 @@ const findTitle = (text: string) => {
   return lines[0] ?? ''
 }
 
+const persistentDataStateMarker = /\s*data-state-persistent(?:=(?:"true"|'true'|true))?/i
+const dataStateAttribute = /\bdata-state\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/i
+
+const applyPersistentDataState = (slides: ISlide[]) => {
+  let persistentState: string | null = null
+  for (const slide of slides.flatMap((slide) => [slide, ...slide.verticalChildren])) {
+    const isPersistent = persistentDataStateMarker.test(slide.attributes)
+    slide.attributes = slide.attributes.replace(persistentDataStateMarker, '').trim()
+    const state = dataStateAttribute.exec(slide.attributes)?.[0] ?? null
+    if (state && isPersistent) {
+      persistentState = state
+    } else if (state) {
+      persistentState = null
+    } else if (persistentState) {
+      slide.attributes = `${slide.attributes} ${persistentState}`.trim()
+    }
+  }
+}
+
 export class SlideParser extends Disposable {
 
   constructor() {
@@ -76,11 +95,13 @@ export class SlideParser extends Disposable {
   #parseSlides = (slideContent: string, separator: string, verticalSeparator: string): ISlide[] => {
     const regex = new RegExp(separator, 'gm')
     const slides = slideContent.split(regex)
-    return slides.map((s, i) => {
+    const parsedSlides = slides.map((s, i) => {
 
       return this.#parseSlide(trimFirstLastEmptyLine(s), i, verticalSeparator)
 
     })
+    applyPersistentDataState(parsedSlides)
+    return parsedSlides
   }
 
 

--- a/src/test/UnitTests/slideparser.jest.ts
+++ b/src/test/UnitTests/slideparser.jest.ts
@@ -182,6 +182,31 @@ test('Persists explicitly marked slide data-state through following and vertical
   expect(slides[3].attributes).toBe('data-state="section-blue"')
 })
 
+test('Does not propagate an unmarked data-state and removes disabled persistence markers', () => {
+  const content = `<!-- .slide: data-state="one" -->
+# One
+
+---
+
+# Default
+
+---
+
+<!-- .slide: data-state="two" data-state-persistent = "false" -->
+# Two
+
+---
+
+# Also default`
+
+  const { slides } = parser.parse(content, defaultConfiguration)
+
+  expect(slides[0].attributes).toBe('data-state="one"')
+  expect(slides[1].attributes).toBe('')
+  expect(slides[2].attributes).toBe('data-state="two"')
+  expect(slides[3].attributes).toBe('')
+})
+
 test('Malformed front matter still returns parsed slides and parser location', () => {
   const malformedFrontMatter = `---
 foo: [

--- a/src/test/UnitTests/slideparser.jest.ts
+++ b/src/test/UnitTests/slideparser.jest.ts
@@ -152,6 +152,36 @@ test('Extract slide attributes', () => {
   })
 })
 
+test('Persists explicitly marked slide data-state through following and vertical slides', () => {
+  const content = `<!-- .slide: data-state="section-red" data-state-persistent -->
+# Red
+
+---
+
+# Still red
+
+--
+
+## Also red
+
+---
+
+<!-- .slide: data-state="section-blue" data-state-persistent -->
+# Blue
+
+---
+
+# Still blue`
+
+  const { slides } = parser.parse(content, defaultConfiguration)
+
+  expect(slides[0].attributes).toBe('data-state="section-red"')
+  expect(slides[1].attributes).toBe('data-state="section-red"')
+  expect(slides[1].verticalChildren[0].attributes).toBe('data-state="section-red"')
+  expect(slides[2].attributes).toBe('data-state="section-blue"')
+  expect(slides[3].attributes).toBe('data-state="section-blue"')
+})
+
 test('Malformed front matter still returns parsed slides and parser location', () => {
   const malformedFrontMatter = `---
 foo: [


### PR DESCRIPTION
## Summary
- add the explicit data-state-persistent marker for slide attributes
- propagate its data-state to following horizontal and vertical slides
- preserve the existing default data-state behavior for unmarked slides

## Validation
- npm test -- --runInBand
- npm run test-compile
- npm run lint

Closes #676