### PR TITLE
Isolate Markdown rendering configuration

### DIFF
--- a/src/Markdown-it.ts
+++ b/src/Markdown-it.ts
@@ -28,29 +28,14 @@ interface IDiagramRenderingConfig {
   mermaidTheme: 'dark' | null
 }
 
-const diagramRenderingConfig: IDiagramRenderingConfig = {
-  enabled: true,
-  serverBaseUrl: DEFAULT_DIAGRAM_SERVER,
-  mermaidTheme: null,
-}
+const normalizeDiagramConfig = (config: Partial<IDiagramRenderingConfig> = {}): IDiagramRenderingConfig => ({
+  enabled: typeof config.enabled === 'boolean' ? config.enabled : true,
+  serverBaseUrl: typeof config.serverBaseUrl === 'string' ? config.serverBaseUrl.trim().replace(/\/$/, '') || DEFAULT_DIAGRAM_SERVER : DEFAULT_DIAGRAM_SERVER,
+  mermaidTheme: config.mermaidTheme === 'dark' ? 'dark' : null,
+})
 
-export const setDiagramRenderingConfig = (config: Partial<IDiagramRenderingConfig>) => {
-  if (typeof config.enabled === 'boolean') {
-    diagramRenderingConfig.enabled = config.enabled
-  }
-
-  if (typeof config.serverBaseUrl === 'string') {
-    const trimmedServerBaseUrl = config.serverBaseUrl.trim().replace(/\/$/, '')
-    diagramRenderingConfig.serverBaseUrl = trimmedServerBaseUrl || DEFAULT_DIAGRAM_SERVER
-  }
-
-  if (config.mermaidTheme === 'dark' || config.mermaidTheme === null) {
-    diagramRenderingConfig.mermaidTheme = config.mermaidTheme
-  }
-}
-
-const withMermaidTheme = (code: string): string => {
-  if (diagramRenderingConfig.mermaidTheme !== 'dark' || code.trimStart().startsWith('%%{')) return code
+const withMermaidTheme = (code: string, config: IDiagramRenderingConfig): string => {
+  if (config.mermaidTheme !== 'dark' || code.trimStart().startsWith('%%{')) return code
   return `%%{init: {'theme':'dark'}}%%\n${code}`
 }
 
@@ -153,7 +138,9 @@ const diagramTypes = [
 ]
 
 
-const markdown = md({
+export const createMarkdownIt = (diagramConfig: Partial<IDiagramRenderingConfig> = {}) => {
+  const renderingConfig = normalizeDiagramConfig(diagramConfig)
+  const markdown = md({
     html: true,
     linkify: true,
     typographer: true,
@@ -182,15 +169,15 @@ const markdown = md({
   const highlight = markdown.options.highlight
   markdown.options.highlight = (code, lang, attr) => {
     if (lang && diagramTypes.indexOf(lang.toLowerCase()) >= 0) {
-      if (!diagramRenderingConfig.enabled) {
+      if (!renderingConfig.enabled) {
         return `<pre><code class="language-${lang.toLowerCase()}">${markdown.utils.escapeHtml(code)}</code></pre>`
       }
 
-      const diagramCode = lang.toLowerCase() === 'mermaid' ? withMermaidTheme(code) : code
+      const diagramCode = lang.toLowerCase() === 'mermaid' ? withMermaidTheme(code, renderingConfig) : code
       const data = Buffer.from(diagramCode, 'utf8')
       const compressed = pako.deflate(data, { level: 9 })
       const result = Buffer.from(compressed).toString('base64').replace(/\+/g, '-').replace(/\//g, '_')
-      return `<pre style="all:unset;"><div><img class="${lang.toLowerCase()}" src="${diagramRenderingConfig.serverBaseUrl}/${lang.toLowerCase()}/svg/${result}" /></div></pre>`
+      return `<pre style="all:unset;"><div><img class="${lang.toLowerCase()}" src="${renderingConfig.serverBaseUrl}/${lang.toLowerCase()}/svg/${result}" /></div></pre>`
     }
     if (highlight !== null && highlight !== undefined) {
       return highlight(code, lang, attr)
@@ -198,5 +185,7 @@ const markdown = md({
 
     return ''
   }
+  return markdown
+}
 
-export default markdown
+export default createMarkdownIt()

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -5,7 +5,7 @@ import ejs from 'ejs'
 import cors from 'cors'
 import morgan from 'morgan'
 import * as path from 'path'
-import markdownit, { setDiagramRenderingConfig } from './Markdown-it'
+import { createMarkdownIt } from './Markdown-it'
 import { exportHTML, IExportOptions } from './ExportHTML'
 import { Disposable } from './dispose'
 import { RevealContext } from './RevealContext'
@@ -185,7 +185,7 @@ export class RevealServer extends Disposable {
         const { init, initModule } = this.loadInitScript()
         const htmlFragmentContent = this.loadHtmlFragmentContent()
 
-        setDiagramRenderingConfig({
+        const markdownit = createMarkdownIt({
           enabled: !offline && context.configuration.diagramServerEnabled,
           serverBaseUrl: context.configuration.diagramServerUrl,
           mermaidTheme: getMermaidTheme(context.configuration.theme),

--- a/src/test/UnitTests/MarkdownItDiagramServer.jest.ts
+++ b/src/test/UnitTests/MarkdownItDiagramServer.jest.ts
@@ -1,4 +1,4 @@
-import markdownit, { setDiagramRenderingConfig } from '../../Markdown-it'
+import markdownit, { createMarkdownIt } from '../../Markdown-it'
 import pako from 'pako'
 
 const getDiagramSource = (html: string): string => {
@@ -9,12 +9,8 @@ const getDiagramSource = (html: string): string => {
 }
 
 describe('Markdown-it diagram server configuration', () => {
-  afterEach(() => {
-    setDiagramRenderingConfig({ enabled: true, serverBaseUrl: 'https://kroki.io', mermaidTheme: null })
-  })
-
   test('uses the configured diagram server base URL', () => {
-    setDiagramRenderingConfig({ serverBaseUrl: 'http://localhost:8000/' })
+    const markdownit = createMarkdownIt({ serverBaseUrl: 'http://localhost:8000/' })
 
     const html = markdownit.render('```mermaid\nflowchart LR\nA-->B\n```')
 
@@ -22,7 +18,7 @@ describe('Markdown-it diagram server configuration', () => {
   })
 
   test('falls back to a local code block when diagram rendering is disabled', () => {
-    setDiagramRenderingConfig({ enabled: false })
+    const markdownit = createMarkdownIt({ enabled: false })
 
     const html = markdownit.render('```plantuml\nAlice -> Bob: hello\n```')
 
@@ -32,19 +28,35 @@ describe('Markdown-it diagram server configuration', () => {
   })
 
   test('trims server base URL and falls back to default when empty', () => {
-    setDiagramRenderingConfig({ serverBaseUrl: '   ' })
+    const markdownit = createMarkdownIt({ serverBaseUrl: '   ' })
     const html = markdownit.render('```mermaid\nflowchart LR\nA-->B\n```')
     expect(html).toContain('src="https://kroki.io/mermaid/svg/')
   })
 
   test('uses Mermaid dark mode for dark Reveal themes without overriding an author directive', () => {
-    setDiagramRenderingConfig({ mermaidTheme: 'dark' })
+    const markdownit = createMarkdownIt({ mermaidTheme: 'dark' })
 
     const themedHtml = markdownit.render('```mermaid\nflowchart LR\nA-->B\n```')
     const explicitHtml = markdownit.render("```mermaid\n%%{init: {'theme':'forest'}}%%\nflowchart LR\nA-->B\n```")
 
     expect(getDiagramSource(themedHtml)).toBe("%%{init: {'theme':'dark'}}%%\nflowchart LR\nA-->B\n")
     expect(getDiagramSource(explicitHtml)).toBe("%%{init: {'theme':'forest'}}%%\nflowchart LR\nA-->B\n")
+  })
+
+  test('keeps diagram rendering configuration isolated between renderers', async () => {
+    const darkRenderer = createMarkdownIt({ serverBaseUrl: 'https://dark.example', mermaidTheme: 'dark' })
+    const disabledRenderer = createMarkdownIt({ enabled: false, serverBaseUrl: 'https://disabled.example' })
+    const source = '```mermaid\nflowchart LR\nA-->B\n```'
+
+    const [darkHtml, disabledHtml] = await Promise.all([
+      Promise.resolve().then(() => darkRenderer.render(source)),
+      Promise.resolve().then(() => disabledRenderer.render(source)),
+    ])
+
+    expect(darkHtml).toContain('src="https://dark.example/mermaid/svg/')
+    expect(getDiagramSource(darkHtml)).toBe("%%{init: {'theme':'dark'}}%%\nflowchart LR\nA-->B\n")
+    expect(disabledHtml).toContain('<pre><code class="language-mermaid">')
+    expect(disabledHtml).not.toContain('dark.example')
   })
 
   test('renders regular markdown syntax and speaker notes conversion', () => {

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -180,6 +180,32 @@ describe('RevealServer', () => {
     context.dispose()
   })
 
+  test('keeps diagram configuration isolated when document servers render concurrently', async () => {
+    const diagramSlide = [{ title: 'Diagram', index: 0, text: '```mermaid\nflowchart LR\nA-->B\n```', verticalChildren: [], attributes: '' }]
+    const onlineContext = createContext({ configuration: { diagramServerUrl: 'https://online.example' } })
+    const offlineContext = createContext({ configuration: { offline: true } })
+    onlineContext.slides = diagramSlide
+    offlineContext.slides = diagramSlide
+    const onlineServer = new RevealServer(onlineContext)
+    const offlineServer = new RevealServer(offlineContext)
+
+    try {
+      const [onlineResponse, offlineResponse] = await Promise.all([
+        request(onlineServer.app).get('/'),
+        request(offlineServer.app).get('/'),
+      ])
+
+      expect(onlineResponse.text).toContain('src="https://online.example/mermaid/svg/')
+      expect(offlineResponse.text).toContain('<pre><code class="language-mermaid">')
+      expect(offlineResponse.text).not.toContain('online.example')
+    } finally {
+      onlineServer.dispose()
+      offlineServer.dispose()
+      onlineContext.dispose()
+      offlineContext.dispose()
+    }
+  })
+
   test('uses Mermaid dark mode with the default black Reveal theme', async () => {
     const context = createContext()
     context.slides = [{ title: 'Diagram', index: 0, text: '```mermaid\nflowchart LR\nA-->B\n```', verticalChildren: [], attributes: '' }]


### PR DESCRIPTION
Fixes #1528\n\n## Summary\n- build a Markdown renderer per Reveal document request\n- keep diagram server and Mermaid theme settings scoped to that renderer\n- cover concurrent document renders with distinct diagram configurations\n\n## Validation\n- npm test -- --runInBand\n- npm run test-compile\n- npm run lint