### PR TITLE
Make webview refreshes race-safe

### DIFF
--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -79,6 +79,11 @@ export default class MainController extends Disposable {
   private OnEditorEvent(editor: TextEditor, newPosition: Position) {
     if (isMarkdownFile(editor.document)) {
       this.currentContext = this.revealContexts.getOrAdd(editor)
+      if (this.exportState && this.exportState.context !== this.currentContext) {
+        const exportState = this.exportState
+        exportState.reject(new Error('HTML export was interrupted because the active document changed'))
+        this.clearExportState(exportState)
+      }
       this.statusBarController.updateServerInfo(this.currentContext?.baseUri || null)
       this.updatePosition(newPosition)
       this.refresh()
@@ -114,7 +119,13 @@ export default class MainController extends Disposable {
     this.revealContexts.remove(document.uri)
 
     if (this.currentContext?.is(document)) {
+      const context = this.currentContext
       this.currentContext = undefined
+      if (this.exportState?.context === context) {
+        const exportState = this.exportState
+        exportState.reject(new Error('HTML export was interrupted because its document was closed'))
+        this.clearExportState(exportState)
+      }
       this.syncAssetWatchers()
     }
 
@@ -209,40 +220,58 @@ export default class MainController extends Disposable {
   }
 
   private exportState: {
+    id: number
+    context: RevealContext
     resolve: (path: string) => void
     reject: (error: Error) => void
     path: string
     selfContained: boolean
   } | null = null
+  private nextExportId = 0
   private configurationRefreshPending = false
-  public isInExport = () => this.exportState !== null
+  public isInExport = (exportId?: number) => this.exportState !== null && (exportId === undefined || this.exportState.id === exportId)
 
-  private readonly onExportError = (error: unknown) => {
-    if (!this.exportState) return
+  private readonly onExportError = (error: unknown, context?: RevealContext, exportId?: number) => {
+    const exportState = this.exportState
+    if (!exportState || (context && exportState.context !== context) || (exportId !== undefined && exportState.id !== exportId)) return
 
     const normalizedError = error instanceof Error ? error : new Error(String(error))
-    this.exportState.reject(new Error(`HTML export failed: ${normalizedError.message}`))
+    exportState.reject(new Error(`HTML export failed: ${normalizedError.message}`))
+    this.clearExportState(exportState)
+  }
+
+  private clearExportState(exportState: NonNullable<MainController['exportState']>, applyPendingConfiguration = true) {
+    if (this.exportState !== exportState) return
     this.exportState = null
+    if (applyPendingConfiguration && this.configurationRefreshPending) {
+      this.configurationRefreshPending = false
+      this.applyConfigurationChanges()
+    }
   }
 
   public shouldOpenFilemanagerAfterHTMLExport = () => this.currentContext?.configuration.openFilemanagerAfterHTMLExport ?? false
 
 
   public exportAsync = async () => {
-    if (!this.currentContext) {
+    const context = this.currentContext
+    if (!context) {
       throw new Error('No active markdown context to export')
     }
 
     if (this.exportState) {
-      this.exportState.reject(new Error('A previous HTML export was interrupted by a new export request'))
-      this.exportState = null
+      const previousExport = this.exportState
+      previousExport.reject(new Error('A previous HTML export was interrupted by a new export request'))
+      this.clearExportState(previousExport)
     }
 
-    await jetpack.removeAsync(this.currentContext.exportPath)
-    const exportPath = this.currentContext.exportPath
+    await jetpack.removeAsync(context.exportPath)
+    if (this.currentContext !== context) {
+      throw new Error('HTML export was interrupted because the active document changed')
+    }
+    const exportPath = context.exportPath
 
     const promise = new Promise<string>((resolve, reject) => {
-      this.exportState = { resolve, reject, path: exportPath, selfContained: this.currentContext!.configuration.selfContained }
+      this.exportState = { id: ++this.nextExportId, context, resolve, reject, path: exportPath, selfContained: context.configuration.selfContained }
     })
 
     if (this.webViewPane) {
@@ -378,7 +407,8 @@ export default class MainController extends Disposable {
 
         const command = 'command' in message ? message.command : undefined
         if (command === 'exportComplete') {
-          void this.completeExport()
+          const exportId = 'exportId' in message ? Number(message.exportId) : Number.NaN
+          void this.completeExport(exportId)
           return
         }
 
@@ -405,28 +435,32 @@ export default class MainController extends Disposable {
     }
   }
 
-  private async completeExport() {
+  private async completeExport(exportId: number) {
     const exportState = this.exportState
-    if (!exportState) return
+    if (!exportState || exportState.id !== exportId) return
     try {
       if (exportState.selfContained) await createSelfContainedExport(exportState.path)
       exportState.resolve(exportState.path)
     } catch (error) {
       exportState.reject(new Error(`HTML export failed: ${error instanceof Error ? error.message : String(error)}`))
     } finally {
-      if (this.exportState === exportState) this.exportState = null
-      if (this.configurationRefreshPending) {
-        this.configurationRefreshPending = false
-        this.applyConfigurationChanges()
-      }
+      this.clearExportState(exportState)
     }
   }
 
   private refreshWebViewPane() {
     if (this.webViewPane && this.currentContext) {
-      this.startServer()
-      this.webViewPane.title = this.currentContext.configuration.title
-      void this.webViewPane.update(this.currentContext.uriWithPosition, this.isInExport())
+      const context = this.currentContext
+      const webViewPane = this.webViewPane
+      const exportState = this.exportState?.context === context ? this.exportState : null
+      const uri = new URL(context.uriWithPosition)
+      if (exportState) uri.searchParams.set('exportId', String(exportState.id))
+      context.startServer()
+      webViewPane.title = context.configuration.title
+      void webViewPane.update(uri.toString(), exportState?.id).catch((error) => {
+        this.logger.error(`WebView refresh failed: ${error instanceof Error ? error.message : String(error)}`)
+        if (exportState) this.onExportError(error, context, exportState.id)
+      })
     }
   }
 
@@ -452,8 +486,9 @@ export default class MainController extends Disposable {
     this.assetWatchers.clear()
 
     if (this.exportState) {
-      this.exportState.reject(new Error('HTML export was interrupted because the extension was disposed'))
-      this.exportState = null
+      const exportState = this.exportState
+      exportState.reject(new Error('HTML export was interrupted because the extension was disposed'))
+      this.clearExportState(exportState, false)
     }
 
     this.currentContext = undefined

--- a/src/RevealContext.ts
+++ b/src/RevealContext.ts
@@ -30,8 +30,8 @@ export class RevealContext extends Disposable {
     public logger: Logger,
     public getConfiguration: () => Configuration,
     public extensionPath: string,
-    public isInExport: () => boolean,
-    public onExportError: (error: unknown) => void = () => {},
+    public isInExport: (exportId?: number) => boolean,
+    public onExportError: (error: unknown, context?: RevealContext, exportId?: number) => void = () => {},
   ) {
     super()
     this.configuration = getConfiguration()

--- a/src/RevealServer.ts
+++ b/src/RevealServer.ts
@@ -208,9 +208,10 @@ export class RevealServer extends Disposable {
   }
 
   /* A middleware function that is used to export the presentation to a folder. */
-  private readonly exportMiddleware = (exportfn: (opts: IExportOptions) => Promise<void>, isInExport: () => boolean) => {
+  private readonly exportMiddleware = (exportfn: (opts: IExportOptions) => Promise<void>, isInExport: (exportId?: number) => boolean) => {
     return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-      if (isInExport()) {
+      const exportId = typeof req.query.exportId === 'string' ? Number(req.query.exportId) : Number.NaN
+      if (Number.isSafeInteger(exportId) && isInExport(exportId)) {
         const { exportPath } = this.context
         this.context.logger.debug('in export')
         const oldWrite = res.write
@@ -249,7 +250,7 @@ export class RevealServer extends Disposable {
             await exportfn(opts)
           } catch (error) {
             this.context.logger.error(`Export error: ${error}`)
-            this.context.onExportError(error)
+            this.context.onExportError(error, this.context, exportId)
           }
 
           // @ts-ignore

--- a/src/WebViewPane.ts
+++ b/src/WebViewPane.ts
@@ -4,6 +4,9 @@ import { Disposable } from "./dispose";
 export default class WebviewPane
     extends Disposable {
 
+    #updateAbortController: AbortController | undefined
+    #updateGeneration = 0
+
     constructor(private webviewPanel:WebviewPanel) {
         super()
         this.webviewPanel.onDidDispose(() => { this.dispose() })
@@ -36,17 +39,31 @@ export default class WebviewPane
         this.webviewPanel.title = title;
     }
     
-    public async update(url:string, sendExportSignal = false) {
+    public async update(url:string, exportId?: number): Promise<boolean> {
+        this.#updateAbortController?.abort()
+        const abortController = new AbortController()
+        this.#updateAbortController = abortController
+        const generation = ++this.#updateGeneration
         const parsedUrl = new URL(url)
         const slideHash = parsedUrl.hash || '#/'
         parsedUrl.hash = ''
 
-        const response = await fetch(parsedUrl.toString())
-        const html = await response.text()
-        const webviewUri = this.webviewPanel.webview.asWebviewUri(Uri.parse(parsedUrl.toString())).toString()
-        const htmlWithBase = this.injectBaseHref(html, webviewUri)
-        this.webviewPanel.webview.html = this.injectBridgeScript(htmlWithBase, slideHash, sendExportSignal)
-        this.#onDidUpdate.fire()
+        try {
+          const response = await fetch(parsedUrl.toString(), { signal: abortController.signal })
+          const html = await response.text()
+          if (abortController.signal.aborted || generation !== this.#updateGeneration) return false
+
+          const webviewUri = this.webviewPanel.webview.asWebviewUri(Uri.parse(parsedUrl.toString())).toString()
+          const htmlWithBase = this.injectBaseHref(html, webviewUri)
+          this.webviewPanel.webview.html = this.injectBridgeScript(htmlWithBase, slideHash, exportId)
+          this.#onDidUpdate.fire()
+          return true
+        } catch (error) {
+          if (abortController.signal.aborted || generation !== this.#updateGeneration) return false
+          throw error
+        } finally {
+          if (this.#updateAbortController === abortController) this.#updateAbortController = undefined
+        }
     }
 
     private injectBaseHref(html: string, baseUrl: string) {
@@ -58,7 +75,7 @@ export default class WebviewPane
       return `${baseTag}${html}`
     }
 
-    private injectBridgeScript(html: string, slideHash: string, sendExportSignal: boolean) {
+    private injectBridgeScript(html: string, slideHash: string, exportId?: number) {
       const script = `
       <script>
         (function () {
@@ -128,9 +145,9 @@ export default class WebviewPane
 
           setTimeout(postCurrentSlide, 0);
 
-          if (${sendExportSignal}) {
+          if (${typeof exportId === 'number'}) {
             const postExportComplete = () => {
-              vscode.postMessage({ command: 'exportComplete' });
+              vscode.postMessage({ command: 'exportComplete', exportId: ${JSON.stringify(exportId)} });
             };
 
             if (document.readyState === 'complete') {
@@ -150,6 +167,7 @@ export default class WebviewPane
     }
   
     public dispose() {
+        this.#updateAbortController?.abort()
         this.#onDidDispose.fire();
         super.dispose();
     }

--- a/src/test/UnitTests/MainController.jest.ts
+++ b/src/test/UnitTests/MainController.jest.ts
@@ -168,7 +168,8 @@ jest.mock('../../WebViewPane', () => ({
   }),
 }))
 
-const logger = new Logger(jest.fn(), LogLevel.Debug)
+const loggerAppendMock = jest.fn()
+const logger = new Logger(loggerAppendMock, LogLevel.Debug)
 
 const editor = {
   document: { languageId: 'markdown', fileName: 'slides.md', uri: 'doc-uri' },
@@ -199,9 +200,12 @@ describe('MainController coverage', () => {
     await Promise.resolve()
   }
 
+  const currentExportId = () => (webViewPaneUpdateMock.mock.calls as unknown[][])[webViewPaneUpdateMock.mock.calls.length - 1]?.[1]
+
   beforeEach(() => {
     jest.useFakeTimers()
     jest.clearAllMocks()
+    loggerAppendMock.mockClear()
     watchers.length = 0
     temporaryContexts.length = 0
     activeTerminalMock = { show: terminalShowMock, sendText: terminalSendTextMock }
@@ -330,7 +334,7 @@ describe('MainController coverage', () => {
 
     const exportPromise = main.exportAsync()
     await flush()
-    receiveMessageListener?.({ command: 'exportComplete' })
+    receiveMessageListener?.({ command: 'exportComplete', exportId: currentExportId() })
     await expect(exportPromise).resolves.toBe('/tmp/export')
 
     disposeListener?.()
@@ -362,6 +366,62 @@ describe('MainController coverage', () => {
     expect(noContextMain.shouldOpenFilemanagerAfterHTMLExport()).toBe(false)
     ;(noContextMain as any).onExportError(new Error('ignored'))
     await expect(noContextMain.exportAsync()).rejects.toThrow('No active markdown context to export')
+  })
+
+  test('ignores an export completion message from a superseded webview page', async () => {
+    const context = makeContext()
+    revealContextsGetOrAddMock.mockReturnValue(context)
+    const main = new MainController(logger, { extensionPath: '/ext' } as any, [], defaultConfiguration, editor as any)
+    main.showWebViewPane()
+
+    const firstExport = main.exportAsync()
+    await flush()
+    const firstExportId = currentExportId()
+    const secondExport = main.exportAsync()
+    await flush()
+    const secondExportId = currentExportId()
+
+    await expect(firstExport).rejects.toThrow('interrupted by a new export request')
+    receiveMessageListener?.({ command: 'exportComplete', exportId: firstExportId })
+    ;(main as any).onExportError(new Error('old export failed'), context, firstExportId)
+    await flush()
+
+    let completed = false
+    void secondExport.then(() => { completed = true })
+    await flush()
+    expect(completed).toBe(false)
+
+    receiveMessageListener?.({ command: 'exportComplete', exportId: secondExportId })
+    await expect(secondExport).resolves.toBe('/tmp/export')
+  })
+
+  test('interrupts an export when the active document changes', async () => {
+    const firstContext = makeContext()
+    const secondContext = makeContext()
+    revealContextsGetOrAddMock.mockReturnValueOnce(firstContext).mockReturnValue(secondContext)
+    const main = new MainController(logger, { extensionPath: '/ext' } as any, [], defaultConfiguration, editor as any)
+    main.showWebViewPane()
+
+    const exportPromise = main.exportAsync()
+    await flush()
+    main.onDidChangeActiveTextEditor({
+      ...editor,
+      document: { ...editor.document, fileName: 'second.md', uri: 'second-doc-uri' },
+    } as any)
+
+    await expect(exportPromise).rejects.toThrow('active document changed')
+  })
+
+  test('handles webview refresh failures without leaving an unhandled promise', async () => {
+    const context = makeContext()
+    revealContextsGetOrAddMock.mockReturnValue(context)
+    webViewPaneUpdateMock.mockRejectedValueOnce(new Error('server unavailable'))
+    const main = new MainController(logger, { extensionPath: '/ext' } as any, [], defaultConfiguration, editor as any)
+
+    main.showWebViewPane()
+    await flush()
+
+    expect(loggerAppendMock).toHaveBeenCalledWith(expect.stringContaining('WebView refresh failed: server unavailable'))
   })
 
   test('asset watcher callbacks trigger quick refresh and goToSlide/updatePosition no-op when context missing', () => {

--- a/src/test/UnitTests/RevealServer.jest.ts
+++ b/src/test/UnitTests/RevealServer.jest.ts
@@ -644,14 +644,14 @@ describe('RevealServer', () => {
     const exporter = jest.fn(async () => {
       throw new Error('boom')
     })
-    type TestRequest = { originalUrl: string }
+    type TestRequest = { originalUrl: string; query: { exportId: string } }
     type TestResponse = { write: (chunk: string) => boolean; end: (chunk: string) => boolean | Promise<boolean> }
     type ExportMiddleware = (req: TestRequest, res: TestResponse, next: () => void) => Promise<void>
     const middleware = (server as unknown as {
-      exportMiddleware: (exportFn: typeof exporter, isInExport: () => boolean) => ExportMiddleware
+      exportMiddleware: (exportFn: typeof exporter, isInExport: (exportId?: number) => boolean) => ExportMiddleware
     }).exportMiddleware(exporter, () => true)
     const next = jest.fn()
-    const req = { originalUrl: '/index.html?x=1' }
+    const req = { originalUrl: '/index.html?exportId=1', query: { exportId: '1' } }
     const res: TestResponse = {
       write: jest.fn((chunk: string) => typeof chunk === 'string'),
       end: jest.fn((chunk: string) => typeof chunk === 'string'),

--- a/src/test/UnitTests/WebviewPane.jest.ts
+++ b/src/test/UnitTests/WebviewPane.jest.ts
@@ -66,7 +66,7 @@ test('Update injects bridge script for slide sync and preserves hash with query 
 
   mockFetch('<html><head></head><body><div>hello</div></body></html>')
 
-  await pane.update('http://localhost:1234/?print-pdf#/2/1', true)
+  await pane.update('http://localhost:1234/?print-pdf#/2/1', 42)
 
   expect(asWebviewUri).toHaveBeenCalled()
   expect(webviewPanel.webview.html).toContain('<base href="vscode-webview://remote/http://localhost:1234/?print-pdf">')
@@ -76,4 +76,27 @@ test('Update injects bridge script for slide sync and preserves hash with query 
   expect(webviewPanel.webview.html).toContain("message.command === 'setSlide'")
   expect(webviewPanel.webview.html).toContain('window.location.hash = initialHash')
   expect(webviewPanel.webview.html).toContain("command: 'exportComplete'")
+  expect(webviewPanel.webview.html).toContain('exportId: 42')
+})
+
+test('Update ignores a superseded fetch that completes after a newer refresh', async () => {
+  const onDidDispose = jest.fn() as Event<void>
+  const onDidReceiveMessage = jest.fn() as Event<unknown>
+  const webviewPanel = { title: 'test', onDidDispose, webview: { html: '', onDidReceiveMessage, asWebviewUri: (uri: { toString(): string }) => uri } } as unknown as WebviewPanel
+  const pane = new WebviewPane(webviewPanel)
+  let resolveFirst: (response: Response) => void = () => undefined
+  let resolveSecond: (response: Response) => void = () => undefined
+  const firstResponse = new Promise<Response>((resolve) => { resolveFirst = resolve })
+  const secondResponse = new Promise<Response>((resolve) => { resolveSecond = resolve })
+  jest.spyOn(global, 'fetch').mockImplementationOnce(() => firstResponse).mockImplementationOnce(() => secondResponse)
+
+  const firstUpdate = pane.update('http://localhost:1234/#/1')
+  const secondUpdate = pane.update('http://localhost:1234/#/2')
+  resolveSecond({ text: async () => '<html><head></head><body>new</body></html>' } as Response)
+  await expect(secondUpdate).resolves.toBe(true)
+  resolveFirst({ text: async () => '<html><head></head><body>old</body></html>' } as Response)
+  await expect(firstUpdate).resolves.toBe(false)
+
+  expect(webviewPanel.webview.html).toContain('new')
+  expect(webviewPanel.webview.html).not.toContain('old')
 })


### PR DESCRIPTION
Fixes #1529\n\n## Summary\n- abort and ignore superseded webview refreshes\n- attach export operations to the document context and a unique identifier\n- ignore stale export-completion messages and handle refresh failures\n\n## Validation\n- npm test -- --runInBand\n- npm run test-compile\n- npm run lint